### PR TITLE
feat(BACK-7721): package and distribute linter as a zipapp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,13 @@ jobs:
         env:
           FURY_TOKEN: ${{ secrets.PYPI_DEPLOY_TOKEN}}
 
-      - name: Build distribution artifacts
+      - name: Build library artifacts
         timeout-minutes: 10
         run: pdm build
+
+      - name: Build standalone application
+        timeout-minutes: 10
+        run: pdm exe
 
       - name: Generate build attestations
         timeout-minutes: 10
@@ -50,10 +54,20 @@ jobs:
         with:
           path: dist
 
-      - name: Upload distribution artifacts to Ledger Artifactory repository
+      - name: Upload library artifacts to Ledger Artifactory repository
         timeout-minutes: 10
         env:
           PDM_PUBLISH_REPO: https://jfrog.ledgerlabs.net/artifactory/api/pypi/vault-pypi-prod-green
           PDM_PUBLISH_USERNAME: ${{ steps.jfrog-login.outputs.oidc-user }}
           PDM_PUBLISH_PASSWORD: ${{ steps.jfrog-login.outputs.oidc-token }}
         run: pdm publish --no-build
+
+      - name: Attach standalone application to Github release
+        uses: svenstaro/upload-release-action@v2
+        timeout-minutes: 10
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          file: dist/erc7730
+          asset_name: erc7730
+          overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tests/**/*.xml
 outputs/**/*.html
 exports
 dist/
+build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,11 @@ test.help = "Run unit/integration tests suite"
 test.shell = "pytest tests"
 all.help = "Run lint+test"
 all.shell = { composite = ["lint", "test"] }
+exe.help = "Package the application into a standalone executable"
+exe.shell = "pdm pack --compress --exe --interpreter '/usr/bin/env python3' --output dist/erc7730"
 
 [tool.pdm]
-plugins = ["sync-pre-commit-lock"]
+plugins = ["sync-pre-commit-lock", "pdm-packer"]
 
 [tool.pdm.dev-dependencies]
 dev = [


### PR DESCRIPTION
https://docs.python.org/3/library/zipapp.html
To workaround access issues from public repository.
Example release: https://github.com/LedgerHQ/python-erc7730/releases/tag/v0.0.15
