### PR TITLE
feat: add utility method to load model

### DIFF
--- a/src/erc7730/linter/lint.py
+++ b/src/erc7730/linter/lint.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 from erc7730 import ERC_7730_REGISTRY_CALLDATA_PREFIX, ERC_7730_REGISTRY_EIP712_PREFIX
-from erc7730.common.pydantic import model_from_json_file_with_includes
 from erc7730.linter import ERC7730Linter
 from erc7730.linter.linter_base import MultiLinter
 from erc7730.linter.linter_transaction_type_classifier_ai import ClassifyTransactionTypeLinter
@@ -46,7 +45,7 @@ def lint_file(path: Path, linter: ERC7730Linter, out: ERC7730Linter.OutputAdder)
         out(output.model_copy(update={"file": path}))
 
     try:
-        descriptor = model_from_json_file_with_includes(path, ERC7730Descriptor)
+        descriptor = ERC7730Descriptor.load(path)
         descriptor = resolve_external_references(descriptor)
         linter.lint(descriptor, adder)
     except Exception as e:

--- a/src/erc7730/model/erc7730_descriptor.py
+++ b/src/erc7730/model/erc7730_descriptor.py
@@ -1,9 +1,13 @@
+from pathlib import Path
+from typing import Union, Optional
+
+from pydantic import ConfigDict, Field
+
+from erc7730.common.pydantic import model_from_json_file_with_includes, model_from_json_file_with_includes_or_none
 from erc7730.model.base import BaseLibraryModel
 from erc7730.model.context import ContractContext, EIP712Context
 from erc7730.model.display import Display
 from erc7730.model.metadata import Metadata
-from pydantic import ConfigDict, Field
-from typing import Union, Optional
 
 
 class ERC7730Descriptor(BaseLibraryModel):
@@ -23,3 +27,11 @@ class ERC7730Descriptor(BaseLibraryModel):
     context: Optional[Union[ContractContext, EIP712Context]] = None
     metadata: Optional[Metadata] = None
     display: Optional[Display] = None
+
+    @classmethod
+    def load(cls, path: Path) -> "ERC7730Descriptor":
+        return model_from_json_file_with_includes(path, ERC7730Descriptor)
+
+    @classmethod
+    def load_or_none(cls, path: Path) -> Optional["ERC7730Descriptor"]:
+        return model_from_json_file_with_includes_or_none(path, ERC7730Descriptor)

--- a/tests/src/erc7730/common/test_datamodel.py
+++ b/tests/src/erc7730/common/test_datamodel.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from erc7730.common.json import read_json_with_includes
-from erc7730.common.pydantic import model_from_json_file_with_includes_or_none, json_file_from_model
+from erc7730.common.pydantic import json_file_from_model
 from erc7730.model.erc7730_descriptor import ERC7730Descriptor
 import pytest
 import glob
@@ -15,7 +15,7 @@ with open("clear-signing-erc7730-registry/specs/erc7730-v1.schema.json", "r") as
 @pytest.mark.parametrize("file", files)
 def test_from_erc7730(file: str) -> None:
     original_dict_with_includes = read_json_with_includes(Path(file))
-    model_erc7730 = model_from_json_file_with_includes_or_none(Path(file), ERC7730Descriptor)
+    model_erc7730 = ERC7730Descriptor.load_or_none(Path(file))
     assert model_erc7730 is not None
     json_str_from_model = json_file_from_model(ERC7730Descriptor, model_erc7730)
     json_from_model = json.loads(json_str_from_model)

--- a/tests/src/erc7730/mapper/test_mapper.py
+++ b/tests/src/erc7730/mapper/test_mapper.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from erc7730.common.pydantic import model_from_json_file_with_includes_or_none
 from erc7730.model.erc7730_descriptor import ERC7730Descriptor
 from erc7730.mapper.mapper import to_eip712_mapper, to_erc7730_mapper
 from eip712 import EIP712DAppDescriptor
@@ -11,7 +10,7 @@ inputs = glob.glob("clear-signing-erc7730-registry/registry/*/eip712*.json")
 
 @pytest.mark.parametrize("input", inputs)
 def test_roundtrip(input: str) -> None:
-    erc7730Descriptor = model_from_json_file_with_includes_or_none(Path(input), ERC7730Descriptor)
+    erc7730Descriptor = ERC7730Descriptor.load_or_none(Path(input))
     assert erc7730Descriptor is not None
     assert isinstance(erc7730Descriptor, ERC7730Descriptor)
     eip712DappDescriptor = to_eip712_mapper(erc7730Descriptor)


### PR DESCRIPTION
`model_from_json_file_with_includes` are also defined in CAL which gets confusing. Make them internal and directly provide `ERC7730Descriptor.load(path)`