### PR TITLE
chore: use eth-utils when possible

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:494f1581b64b1d7e745ffe2e4e22813054be8073203b816f00b374e176bcc2cf"
+content_hash = "sha256:958c216c0e247c917cac6ba5b1e1ce895d6f7d0f5f5a11a26c48cc2cd7588231"
 
 [[metadata.targets]]
 requires_python = ">=3.12,<3.13"
@@ -174,6 +174,34 @@ files = [
 ]
 
 [[package]]
+name = "cytoolz"
+version = "0.12.3"
+requires_python = ">=3.7"
+summary = "Cython implementation of Toolz: High performance functional utilities"
+groups = ["default"]
+marker = "implementation_name == \"cpython\""
+dependencies = [
+    "toolz>=0.8.0",
+]
+files = [
+    {file = "cytoolz-0.12.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:86923d823bd19ce35805953b018d436f6b862edd6a7c8b747a13d52b39ed5716"},
+    {file = "cytoolz-0.12.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3e61acfd029bfb81c2c596249b508dfd2b4f72e31b7b53b62e5fb0507dd7293"},
+    {file = "cytoolz-0.12.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd728f4e6051af6af234651df49319da1d813f47894d4c3c8ab7455e01703a37"},
+    {file = "cytoolz-0.12.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fe8c6267caa7ec67bcc37e360f0d8a26bc3bdce510b15b97f2f2e0143bdd3673"},
+    {file = "cytoolz-0.12.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99462abd8323c52204a2a0ce62454ce8fa0f4e94b9af397945c12830de73f27e"},
+    {file = "cytoolz-0.12.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da125221b1fa25c690fcd030a54344cecec80074df018d906fc6a99f46c1e3a6"},
+    {file = "cytoolz-0.12.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c18e351956f70db9e2d04ff02f28e9a41839250d3f936a4c8a1eabd1c3094d2"},
+    {file = "cytoolz-0.12.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:921e6d2440ac758c4945c587b1d1d9b781b72737ac0c0ca5d5e02ca1db8bded2"},
+    {file = "cytoolz-0.12.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:1651a9bd591a8326329ce1d6336f3129161a36d7061a4d5ea9e5377e033364cf"},
+    {file = "cytoolz-0.12.3-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:8893223b87c2782bd59f9c4bd5c7bf733edd8728b523c93efb91d7468b486528"},
+    {file = "cytoolz-0.12.3-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:e4d2961644153c5ae186db964aa9f6109da81b12df0f1d3494b4e5cf2c332ee2"},
+    {file = "cytoolz-0.12.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:71b6eb97f6695f7ba8ce69c49b707a351c5f46fd97f5aeb5f6f2fb0d6e72b887"},
+    {file = "cytoolz-0.12.3-cp312-cp312-win32.whl", hash = "sha256:cee3de65584e915053412cd178729ff510ad5f8f585c21c5890e91028283518f"},
+    {file = "cytoolz-0.12.3-cp312-cp312-win_amd64.whl", hash = "sha256:9eef0d23035fa4dcfa21e570961e86c375153a7ee605cdd11a8b088c24f707f6"},
+    {file = "cytoolz-0.12.3.tar.gz", hash = "sha256:4503dc59f4ced53a54643272c61dc305d1dbbfbd7d6bdf296948de9f34c3a282"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.8"
 summary = "Distribution utilities"
@@ -209,19 +237,35 @@ files = [
 ]
 
 [[package]]
-name = "eth-hash"
-version = "0.7.0"
-extras = ["pycryptodome"]
-requires_python = ">=3.8, <4"
-summary = "eth-hash: The Ethereum hashing function, keccak256, sometimes (erroneously) called sha3"
+name = "eth-typing"
+version = "5.0.0"
+requires_python = "<4,>=3.8"
+summary = "eth-typing: Common type annotations for ethereum python packages"
 groups = ["default"]
 dependencies = [
-    "eth-hash==0.7.0",
-    "pycryptodome<4,>=3.6.6",
+    "typing-extensions>=4.5.0",
 ]
 files = [
-    {file = "eth-hash-0.7.0.tar.gz", hash = "sha256:bacdc705bfd85dadd055ecd35fd1b4f846b671add101427e089a4ca2e8db310a"},
-    {file = "eth_hash-0.7.0-py3-none-any.whl", hash = "sha256:b8d5a230a2b251f4a291e3164a23a14057c4a6de4b0aa4a16fa4dc9161b57e2f"},
+    {file = "eth_typing-5.0.0-py3-none-any.whl", hash = "sha256:c7ebc8595e7b65175bb4b4176c2b548ab21b13329f2058e84d4f8c289ba9f577"},
+    {file = "eth_typing-5.0.0.tar.gz", hash = "sha256:87ce7cee75665c09d2dcff8de1b496609d5e32fcd2e2b1d8fc0370c29eedcdc0"},
+]
+
+[[package]]
+name = "eth-utils"
+version = "5.0.0"
+requires_python = "<4,>=3.8"
+summary = "eth-utils: Common utility functions for python code that interacts with Ethereum"
+groups = ["default"]
+dependencies = [
+    "cytoolz>=0.10.1; implementation_name == \"cpython\"",
+    "eth-hash>=0.3.1",
+    "eth-typing>=5.0.0",
+    "hexbytes>=1.0.0",
+    "toolz>0.8.2; implementation_name == \"pypy\"",
+]
+files = [
+    {file = "eth_utils-5.0.0-py3-none-any.whl", hash = "sha256:99c44eca11db74dbb881a1d70b24cd80436fc62fe527d2f5c3e3cf7932aba7b2"},
+    {file = "eth_utils-5.0.0.tar.gz", hash = "sha256:a5eb9555f43f4579eb83cb84f9dda9f3d6663bbd4a5a6b693f8d35045f305a1f"},
 ]
 
 [[package]]
@@ -258,6 +302,17 @@ dependencies = [
 files = [
     {file = "future_fstrings-1.2.0-py2.py3-none-any.whl", hash = "sha256:90e49598b553d8746c4dc7d9442e0359d038c3039d802c91c0a55505da318c63"},
     {file = "future_fstrings-1.2.0.tar.gz", hash = "sha256:6cf41cbe97c398ab5a81168ce0dbb8ad95862d3caf23c21e4430627b90844089"},
+]
+
+[[package]]
+name = "hexbytes"
+version = "1.2.1"
+requires_python = "<4,>=3.8"
+summary = "hexbytes: Python `bytes` subclass that decodes hex, with a readable console output"
+groups = ["default"]
+files = [
+    {file = "hexbytes-1.2.1-py3-none-any.whl", hash = "sha256:e64890b203a31f4a23ef11470ecfcca565beaee9198df623047df322b757471a"},
+    {file = "hexbytes-1.2.1.tar.gz", hash = "sha256:515f00dddf31053db4d0d7636dd16061c1d896c3109b8e751005db4ca46bcca7"},
 ]
 
 [[package]]
@@ -492,26 +547,6 @@ groups = ["dev"]
 files = [
     {file = "py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690"},
     {file = "py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5"},
-]
-
-[[package]]
-name = "pycryptodome"
-version = "3.20.0"
-requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-summary = "Cryptographic library for Python"
-groups = ["default"]
-files = [
-    {file = "pycryptodome-3.20.0-cp35-abi3-macosx_10_9_universal2.whl", hash = "sha256:ac1c7c0624a862f2e53438a15c9259d1655325fc2ec4392e66dc46cdae24d044"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76658f0d942051d12a9bd08ca1b6b34fd762a8ee4240984f7c06ddfb55eaf15a"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f35d6cee81fa145333137009d9c8ba90951d7d77b67c79cbe5f03c7eb74d8fe2"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76cb39afede7055127e35a444c1c041d2e8d2f1f9c121ecef573757ba4cd2c3c"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49a4c4dc60b78ec41d2afa392491d788c2e06edf48580fbfb0dd0f828af49d25"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:fb3b87461fa35afa19c971b0a2b7456a7b1db7b4eba9a8424666104925b78128"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-musllinux_1_1_i686.whl", hash = "sha256:acc2614e2e5346a4a4eab6e199203034924313626f9620b7b4b38e9ad74b7e0c"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:210ba1b647837bfc42dd5a813cdecb5b86193ae11a3f5d972b9a0ae2c7e9e4b4"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-win32.whl", hash = "sha256:8d6b98d0d83d21fb757a182d52940d028564efe8147baa9ce0f38d057104ae72"},
-    {file = "pycryptodome-3.20.0-cp35-abi3-win_amd64.whl", hash = "sha256:9b3ae153c89a480a0ec402e23db8d8d84a3833b65fa4b15b81b83be9d637aab9"},
-    {file = "pycryptodome-3.20.0.tar.gz", hash = "sha256:09609209ed7de61c2b560cc5c8c4fbf892f8b15b1faf7e4cbffac97db1fffda7"},
 ]
 
 [[package]]
@@ -914,6 +949,18 @@ groups = ["dev"]
 files = [
     {file = "termcolor-2.4.0-py3-none-any.whl", hash = "sha256:9297c0df9c99445c2412e832e882a7884038a25617c60cea2ad69488d4040d63"},
     {file = "termcolor-2.4.0.tar.gz", hash = "sha256:aab9e56047c8ac41ed798fa36d892a37aca6b3e9159f3e0c24bc64a9b3ac7b7a"},
+]
+
+[[package]]
+name = "toolz"
+version = "0.12.1"
+requires_python = ">=3.7"
+summary = "List processing tools and functional utilities"
+groups = ["default"]
+marker = "implementation_name == \"pypy\" or implementation_name == \"cpython\""
+files = [
+    {file = "toolz-0.12.1-py3-none-any.whl", hash = "sha256:d22731364c07d72eea0a0ad45bafb2c2937ab6fd38a3507bf55eae8744aa7d85"},
+    {file = "toolz-0.12.1.tar.gz", hash = "sha256:ecca342664893f177a13dac0e6b41cbd8ac25a358e5f215316d43e2100224f4d"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "eip712-clearsign>=2.1.0",
     "requests>=2.32.3",
     "typer>=0.12.5",
-    "eth-hash[pycryptodome]>=0.7.0",
+    "eth-utils>=5.0.0",
     "jsonschema",
     "eth_hash",
     "rich",
@@ -107,7 +107,17 @@ omit = ["tests/*"]
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "N", "UP", "B", "SIM", "I", "TID", "RUF"] # see https://docs.astral.sh/ruff/rules
+select = [
+    "E",
+    "F",
+    "N",
+    "UP",
+    "B",
+    "SIM",
+    "I",
+    "TID",
+    "RUF",
+] # see https://docs.astral.sh/ruff/rules
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]

--- a/src/erc7730/lint/lint_validate_display_fields.py
+++ b/src/erc7730/lint/lint_validate_display_fields.py
@@ -1,6 +1,6 @@
 from typing import final, override
 
-from erc7730.common.abi import compute_keccak, compute_paths, compute_selector, reduce_signature
+from erc7730.common.abi import compute_paths, function_to_selector, reduce_signature, signature_to_selector
 from erc7730.common.output import OutputAdder
 from erc7730.lint import ERC7730Linter
 from erc7730.lint.common.paths import compute_eip712_paths, compute_format_paths
@@ -76,13 +76,13 @@ class ValidateDisplayFieldsLinter(ERC7730Linter):
             abi_paths_by_selector: dict[str, set[str]] = {}
             for abi in descriptor.context.contract.abi:
                 if abi.type == "function":
-                    abi_paths_by_selector[compute_selector(abi)] = compute_paths(abi)
+                    abi_paths_by_selector[function_to_selector(abi)] = compute_paths(abi)
 
             for selector, fmt in descriptor.display.formats.items():
                 keccak = selector
                 if not selector.startswith("0x"):
                     if (reduced_signature := reduce_signature(selector)) is not None:
-                        keccak = compute_keccak(reduced_signature)
+                        keccak = signature_to_selector(reduced_signature)
                     else:
                         out.error(
                             title="Invalid selector",

--- a/tests/common/test_abi.py
+++ b/tests/common/test_abi.py
@@ -1,39 +1,39 @@
-from erc7730.common.abi import compute_keccak, compute_paths, compute_signature, reduce_signature
+from erc7730.common.abi import compute_paths, compute_signature, reduce_signature, signature_to_selector
 from erc7730.model.abi import Component, Function, InputOutput
 
 # Thank you Github Copilot for generating the tests below!
 
 
-def test_reduce_signature_no_params():
+def test_reduce_signature_no_params() -> None:
     signature = "transfer()"
     expected = "transfer()"
     assert reduce_signature(signature) == expected
 
 
-def test_reduce_signature_without_names():
+def test_reduce_signature_without_names() -> None:
     signature = "transfer(address)"
     expected = "transfer(address)"
     assert reduce_signature(signature) == expected
 
 
-def test_reduce_signature_with_names_and_spaces():
+def test_reduce_signature_with_names_and_spaces() -> None:
     signature = "mintToken(uint256 eventId, uint256 tokenId, address receiver, uint256 expirationTime, bytes signature)"
     expected = "mintToken(uint256,uint256,address,uint256,bytes)"
     assert reduce_signature(signature) == expected
 
 
-def test_reduce_signature_invalid():
+def test_reduce_signature_invalid() -> None:
     signature = "invalid_signature"
     assert reduce_signature(signature) is None
 
 
-def test_compute_signature_no_params():
+def test_compute_signature_no_params() -> None:
     abi = Function(name="transfer", inputs=[])
     expected = "transfer()"
     assert compute_signature(abi) == expected
 
 
-def test_compute_signature_with_params():
+def test_compute_signature_with_params() -> None:
     abi = Function(
         name="transfer", inputs=[InputOutput(name="to", type="address"), InputOutput(name="amount", type="uint256")]
     )
@@ -41,7 +41,7 @@ def test_compute_signature_with_params():
     assert compute_signature(abi) == expected
 
 
-def test_compute_signature_with_nested_params():
+def test_compute_signature_with_nested_params() -> None:
     abi = Function(
         name="foo",
         inputs=[
@@ -56,26 +56,19 @@ def test_compute_signature_with_nested_params():
     assert compute_signature(abi) == expected
 
 
-def test_compute_signature_with_signature():
-    abi = Function(name="transfer", inputs=[], signature="transfer(address,uint256)")
-    expected = "transfer(address,uint256)"
-    assert compute_signature(abi) == expected
-
-
-def test_compute_keccak():
-    # https://emn178.github.io/online-tools/keccak_256.html
+def test_signature_to_selector() -> None:
     signature = "transfer(address,uint256)"
     expected = "0xa9059cbb"
-    assert compute_keccak(signature) == expected
+    assert signature_to_selector(signature) == expected
 
 
-def test_compute_paths_no_params():
+def test_compute_paths_no_params() -> None:
     abi = Function(name="transfer", inputs=[])
-    expected = set()
+    expected: set[str] = set()
     assert compute_paths(abi) == expected
 
 
-def test_compute_paths_with_params():
+def test_compute_paths_with_params() -> None:
     abi = Function(
         name="transfer", inputs=[InputOutput(name="to", type="address"), InputOutput(name="amount", type="uint256")]
     )
@@ -83,7 +76,7 @@ def test_compute_paths_with_params():
     assert compute_paths(abi) == expected
 
 
-def test_compute_paths_with_nested_params():
+def test_compute_paths_with_nested_params() -> None:
     abi = Function(
         name="foo",
         inputs=[
@@ -98,7 +91,7 @@ def test_compute_paths_with_nested_params():
     assert compute_paths(abi) == expected
 
 
-def test_compute_paths_with_multiple_nested_params():
+def test_compute_paths_with_multiple_nested_params() -> None:
     abi = Function(
         name="foo",
         inputs=[


### PR DESCRIPTION
- `reduce_signature` is required as signature is not parsed by `function_signature_to_4byte_selector`, therefore signatures with and without parameter names result in different selectors (and there is no signature -> ABI utility method)
- Test coverage kept

Unrelated changes: renaming and linting
