### PR TITLE
chore: linter: return exit code 0 if there are only warnings

### DIFF
--- a/src/erc7730/lint/lint.py
+++ b/src/erc7730/lint/lint.py
@@ -25,7 +25,7 @@ def lint_all_and_print_errors(paths: list[Path], gha: bool) -> bool:
 
     if out.has_warnings:
         print("[yellow]some warnings found ⚠️[/yellow]")
-        return False
+        return True
 
     print("[green]no issues found ✅[/green]")
     return True


### PR DESCRIPTION
(demo feedback)