### PR TITLE
fix: improve ABI paths discovery and signature reduction

### DIFF
--- a/tests/lint/test_lint.py
+++ b/tests/lint/test_lint.py
@@ -12,9 +12,4 @@ def test_registry_files(input_file: Path) -> None:
     """
     Test linting ERC-7730 registry files, which should all be valid at all times.
     """
-
-    # TODO: invalid files in registry
-    if input_file.name in {"calldata-AugustusSwapper.json"}:
-        pytest.skip("addressName `type` must be changed to `types`")
-
     assert lint_all_and_print_errors([input_file])


### PR DESCRIPTION
- Generate array ABI path for array types
- Move to regex-based substitution rather than incomplete parsing for `reduce_signature`

First fix is not enough to fix linter issues on https://github.com/LedgerHQ/clear-signing-erc7730-registry/blob/master/registry/paraswap/calldata-AugustusSwapper.json however second fix should allow to progress on https://github.com/LedgerHQ/clear-signing-erc7730-registry/pull/56 