### PR TITLE
feat: add `erc7730` command to print JSON schemas

### DIFF
--- a/src/erc7730/model/__init__.py
+++ b/src/erc7730/model/__init__.py
@@ -1,1 +1,12 @@
 """Package implementing an object model for ERC-7730 descriptors."""
+
+from enum import StrEnum, auto
+
+
+class ERC7730ModelType(StrEnum):
+    """
+    The type of the ERC-7730 model.
+    """
+
+    INPUT = auto()
+    RESOLVED = auto()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,11 @@
+import json
 from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
 from erc7730.main import app
+from erc7730.model import ERC7730ModelType
 from tests.cases import path_id
 from tests.files import ERC7730_DESCRIPTORS, ERC7730_EIP712_DESCRIPTORS, LEGACY_EIP712_DESCRIPTORS
 
@@ -16,6 +18,14 @@ def test_help() -> None:
     assert "ERC-7730" in out
     assert "convert" in out
     assert "lint" in out
+
+
+@pytest.mark.parametrize("model_type", list(ERC7730ModelType))
+def test_schema(model_type: ERC7730ModelType) -> None:
+    result = runner.invoke(app, ["schema", model_type])
+    out = "".join(result.stdout.splitlines())
+    assert result.exit_code == 0
+    assert json.loads(out) is not None
 
 
 @pytest.mark.parametrize("input_file", ERC7730_DESCRIPTORS, ids=path_id)


### PR DESCRIPTION
Example:
```
erc7730 schema # prints JSON schema for input form
erc7730 schema resolved # prints JSON schema for resolved form
```

related to discussion at https://ledger.slack.com/archives/C05QLKE9STU/p1729090222378159?thread_ts=1729086060.207889&cid=C05QLKE9STU