### PR TITLE
feat: add `erc7730 resolve` command to convert descriptor to resolved form

### DIFF
--- a/src/erc7730/main.py
+++ b/src/erc7730/main.py
@@ -72,6 +72,30 @@ def lint(
         raise Exit(1)
 
 
+@app.command(
+    name="resolve",
+    short_help="Convert descriptor to resolved form.",
+    help="""
+    Convert descriptor to resolved form:
+        - URLs fetched
+        - Contract addresses normalized to lowercase
+        - References inlined
+        - Constants inlined
+        - Field definitions inlined
+        - Selectors converted to 4 bytes form
+    
+    See `erc7730 schema resolved` for the resolved descriptor schema.
+    """,
+)
+def resolve(
+    input_path: Annotated[Path, Argument(help="The input ERC-7730 file path")],
+) -> None:
+    input_descriptor = InputERC7730Descriptor.load(input_path)
+    if (resolved_descriptor := ERC7730InputToResolved().convert(input_descriptor, ConsoleOutputAdder())) is None:
+        raise Exit(1)
+    print(resolved_descriptor.to_json_string())
+
+
 @convert_app.command(
     name="eip712-to-erc7730",
     short_help="Convert a legacy EIP-712 descriptor file to an ERC-7730 file.",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,6 +42,13 @@ def test_lint_registry_files(input_file: Path) -> None:
     )
 
 
+@pytest.mark.parametrize("input_file", ERC7730_DESCRIPTORS, ids=path_id)
+def test_resolve_registry_files(input_file: Path) -> None:
+    result = runner.invoke(app, ["resolve", str(input_file)])
+    out = "".join(result.stdout.splitlines())
+    assert json.loads(out) is not None
+
+
 @pytest.mark.parametrize("input_file", LEGACY_EIP712_DESCRIPTORS, ids=path_id)
 def test_convert_legacy_registry_eip712_files(input_file: Path, tmp_path: Path) -> None:
     result = runner.invoke(app, ["convert", "eip712-to-erc7730", str(input_file), str(tmp_path / input_file.name)])


### PR DESCRIPTION
Example:
```
$ erc7730 resolve tests/registries/clear-signing-erc7730-registry/registry/lido/calldata-stETH.json
```

