### PR TITLE
feat: support all Etherscan based chains, add support for `file://` URLs, improve linter outputs

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,10 +5,21 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:48ae2022d1d11a1f092dbf654eb0d3afb49f1ee13974370fd7b9cc528279a1a6"
+content_hash = "sha256:fcd73d41a44f479d4d44815663f04e6dea4aab64ac56414b2247975179be0685"
 
 [[metadata.targets]]
 requires_python = ">=3.12,<3.13"
+
+[[package]]
+name = "aiofiles"
+version = "24.1.0"
+requires_python = ">=3.8"
+summary = "File support for asyncio."
+groups = ["default"]
+files = [
+    {file = "aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5"},
+    {file = "aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c"},
+]
 
 [[package]]
 name = "alabaster"
@@ -33,6 +44,23 @@ dependencies = [
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+]
+
+[[package]]
+name = "anyio"
+version = "4.6.2.post1"
+requires_python = ">=3.9"
+summary = "High level compatibility layer for multiple asynchronous event loop implementations"
+groups = ["default"]
+dependencies = [
+    "exceptiongroup>=1.0.2; python_version < \"3.11\"",
+    "idna>=2.8",
+    "sniffio>=1.1",
+    "typing-extensions>=4.1; python_version < \"3.11\"",
+]
+files = [
+    {file = "anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d"},
+    {file = "anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c"},
 ]
 
 [[package]]
@@ -136,7 +164,7 @@ name = "charset-normalizer"
 version = "3.4.0"
 requires_python = ">=3.7.0"
 summary = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-groups = ["default", "dev"]
+groups = ["dev"]
 files = [
     {file = "charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0713f3adb9d03d49d365b70b84775d0a0d18e4ab08d12bc46baa6132ba78aaf6"},
     {file = "charset_normalizer-3.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:de7376c29d95d6719048c194a9cf1a1b0393fbe8488a22008610b0361d834ecf"},
@@ -387,6 +415,20 @@ files = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.14.0"
+requires_python = ">=3.7"
+summary = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+groups = ["default"]
+dependencies = [
+    "typing-extensions; python_version < \"3.8\"",
+]
+files = [
+    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
+    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+]
+
+[[package]]
 name = "hexbytes"
 version = "1.2.1"
 requires_python = "<4,>=3.8"
@@ -395,6 +437,69 @@ groups = ["default"]
 files = [
     {file = "hexbytes-1.2.1-py3-none-any.whl", hash = "sha256:e64890b203a31f4a23ef11470ecfcca565beaee9198df623047df322b757471a"},
     {file = "hexbytes-1.2.1.tar.gz", hash = "sha256:515f00dddf31053db4d0d7636dd16061c1d896c3109b8e751005db4ca46bcca7"},
+]
+
+[[package]]
+name = "hishel"
+version = "0.0.33"
+requires_python = ">=3.8"
+summary = "Persistent cache implementation for httpx and httpcore"
+groups = ["default"]
+dependencies = [
+    "httpx>=0.22.0",
+    "typing-extensions>=4.8.0",
+]
+files = [
+    {file = "hishel-0.0.33-py3-none-any.whl", hash = "sha256:6e6c6cdaf432ff4c4981e7792ef7d1fa4c8ede58b9dbbcefb9ab3fc9770f2a07"},
+    {file = "hishel-0.0.33.tar.gz", hash = "sha256:ab5b2661d5e2252f305fd0fb20e8c76bfab3ea73458f20f2591c53c37b270089"},
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.6"
+requires_python = ">=3.8"
+summary = "A minimal low-level HTTP client."
+groups = ["default"]
+dependencies = [
+    "certifi",
+    "h11<0.15,>=0.13",
+]
+files = [
+    {file = "httpcore-1.0.6-py3-none-any.whl", hash = "sha256:27b59625743b85577a8c0e10e55b50b5368a4f2cfe8cc7bcfa9cf00829c2682f"},
+    {file = "httpcore-1.0.6.tar.gz", hash = "sha256:73f6dbd6eb8c21bbf7ef8efad555481853f5f6acdeaff1edb0694289269ee17f"},
+]
+
+[[package]]
+name = "httpx"
+version = "0.27.2"
+requires_python = ">=3.8"
+summary = "The next generation HTTP client."
+groups = ["default"]
+dependencies = [
+    "anyio",
+    "certifi",
+    "httpcore==1.*",
+    "idna",
+    "sniffio",
+]
+files = [
+    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
+    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
+]
+
+[[package]]
+name = "httpx-file"
+version = "0.2.0"
+requires_python = ">=3.6.1"
+summary = "File transport adapter for httpx."
+groups = ["default"]
+dependencies = [
+    "aiofiles",
+    "httpx>=0.20",
+]
+files = [
+    {file = "httpx-file-0.2.0.tar.gz", hash = "sha256:a00f1dd02c9ffb5e7e072205c30f7ae0d867c397318b045a40b3268f2cdfa932"},
+    {file = "httpx_file-0.2.0-py3-none-any.whl", hash = "sha256:9a425b351bf65aa394c02096204dc3fa8b647573a289079f927d3e3abfa3c7c8"},
 ]
 
 [[package]]
@@ -497,6 +602,21 @@ groups = ["default"]
 files = [
     {file = "lark-1.2.2-py3-none-any.whl", hash = "sha256:c2276486b02f0f1b90be155f2c8ba4a8e194d42775786db622faccd652d8e80c"},
     {file = "lark-1.2.2.tar.gz", hash = "sha256:ca807d0162cd16cef15a8feecb862d7319e7a09bdb13aef927968e45040fed80"},
+]
+
+[[package]]
+name = "limiter"
+version = "0.5.0"
+requires_python = ">=3.10"
+summary = "⏲️ Easy rate limiting for Python. Rate limiting async and thread-safe decorators and context managers that use a token bucket algorithm."
+groups = ["default"]
+dependencies = [
+    "strenum<0.5.0,>=0.4.7",
+    "token-bucket<0.4.0,>=0.3.0",
+]
+files = [
+    {file = "limiter-0.5.0-py2.py3-none-any.whl", hash = "sha256:920ee7587596b6421690ee2009a755a9970b743001567ae1005310d9b654985c"},
+    {file = "limiter-0.5.0.tar.gz", hash = "sha256:71b9e972e04f1dcf3fa9b541ca3a16dcc1be6ce0d6a12407b25a0888a57e612f"},
 ]
 
 [[package]]
@@ -1039,7 +1159,7 @@ name = "requests"
 version = "2.32.3"
 requires_python = ">=3.8"
 summary = "Python HTTP for Humans."
-groups = ["default", "dev"]
+groups = ["dev"]
 dependencies = [
     "certifi>=2017.4.17",
     "charset-normalizer<4,>=2",
@@ -1155,6 +1275,17 @@ groups = ["default", "dev"]
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+requires_python = ">=3.7"
+summary = "Sniff out which async library your code is running under"
+groups = ["default"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
 ]
 
 [[package]]
@@ -1378,6 +1509,16 @@ files = [
 ]
 
 [[package]]
+name = "strenum"
+version = "0.4.15"
+summary = "An Enum that inherits from str."
+groups = ["default"]
+files = [
+    {file = "StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659"},
+    {file = "StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff"},
+]
+
+[[package]]
 name = "termcolor"
 version = "2.5.0"
 requires_python = ">=3.9"
@@ -1386,6 +1527,17 @@ groups = ["dev"]
 files = [
     {file = "termcolor-2.5.0-py3-none-any.whl", hash = "sha256:37b17b5fc1e604945c2642c872a3764b5d547a48009871aea3edd3afa180afb8"},
     {file = "termcolor-2.5.0.tar.gz", hash = "sha256:998d8d27da6d48442e8e1f016119076b690d962507531df4890fcd2db2ef8a6f"},
+]
+
+[[package]]
+name = "token-bucket"
+version = "0.3.0"
+requires_python = ">=3.5"
+summary = "Very fast implementation of the token bucket algorithm."
+groups = ["default"]
+files = [
+    {file = "token_bucket-0.3.0-py2.py3-none-any.whl", hash = "sha256:6df24309e3cf5b808ae5ef714a3191ec5b54f48c34ef959e4882eef140703369"},
+    {file = "token_bucket-0.3.0.tar.gz", hash = "sha256:979571c99db2ff9e651f2b2146a62b2ebadf7de6c217a8781698282976cb675f"},
 ]
 
 [[package]]
@@ -1476,7 +1628,7 @@ name = "urllib3"
 version = "2.2.3"
 requires_python = ">=3.8"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
-groups = ["default", "dev"]
+groups = ["dev"]
 files = [
     {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
     {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
@@ -1497,4 +1649,15 @@ dependencies = [
 files = [
     {file = "virtualenv-20.26.6-py3-none-any.whl", hash = "sha256:7345cc5b25405607a624d8418154577459c3e0277f5466dd79c49d5e492995f2"},
     {file = "virtualenv-20.26.6.tar.gz", hash = "sha256:280aede09a2a5c317e409a00102e7077c6432c5a38f0ef938e643805a7ad2c48"},
+]
+
+[[package]]
+name = "xdg-base-dirs"
+version = "6.0.2"
+requires_python = "<4.0,>=3.10"
+summary = "Variables defined by the XDG Base Directory Specification"
+groups = ["default"]
+files = [
+    {file = "xdg_base_dirs-6.0.2-py3-none-any.whl", hash = "sha256:3c01d1b758ed4ace150ac960ac0bd13ce4542b9e2cdf01312dcda5012cfebabe"},
+    {file = "xdg_base_dirs-6.0.2.tar.gz", hash = "sha256:950504e14d27cf3c9cb37744680a43bf0ac42efefc4ef4acf98dc736cab2bced"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 dependencies = [
     "pydantic>=2.8.2",
     "eip712-clearsign>=3.0.1",
-    "requests>=2.32.3",
     "typer>=0.12.5",
     "eth-utils>=5.0.0",
     "jsonschema",
@@ -30,6 +29,11 @@ dependencies = [
     "typer",
     "lark>=1.2.2",
     "pydantic-string-url>=1.0.2",
+    "httpx>=0.27.2",
+    "httpx-file>=0.2.0",
+    "hishel>=0.0.33",
+    "xdg-base-dirs>=6.0.2",
+    "limiter>=0.5.0",
 ]
 
 [project.urls]

--- a/src/erc7730/convert/resolved/convert_erc7730_input_to_resolved.py
+++ b/src/erc7730/convert/resolved/convert_erc7730_input_to_resolved.py
@@ -1,6 +1,5 @@
 from typing import assert_never, final, override
 
-from pydantic import RootModel
 from pydantic_string_url import HttpUrl
 
 from erc7730.common import client
@@ -104,8 +103,14 @@ class ERC7730InputToResolved(ERC7730Converter[InputERC7730Descriptor, ResolvedER
     @classmethod
     def _resolve_enum(cls, enum: HttpUrl | EnumDefinition, out: OutputAdder) -> dict[str, str] | None:
         match enum:
-            case HttpUrl():
-                return client.get(enum, RootModel[EnumDefinition]).root
+            case HttpUrl() as url:
+                try:
+                    return client.get(url=url, model=EnumDefinition)
+                except Exception as e:
+                    return out.error(
+                        title="Failed to fetch enum definition from URL",
+                        message=f'Failed to fetch enum definition from URL "{url}": {e}',
+                    )
             case dict():
                 return enum
             case _:
@@ -132,8 +137,14 @@ class ERC7730InputToResolved(ERC7730Converter[InputERC7730Descriptor, ResolvedER
     @classmethod
     def _resolve_abis(cls, abis: list[ABI] | HttpUrl, out: OutputAdder) -> list[ABI] | None:
         match abis:
-            case HttpUrl():
-                return client.get(abis, RootModel[list[ABI]]).root
+            case HttpUrl() as url:
+                try:
+                    return client.get(url=url, model=list[ABI])
+                except Exception as e:
+                    return out.error(
+                        title="Failed to fetch ABI from URL",
+                        message=f'Failed to fetch ABI from URL "{url}": {e}',
+                    )
             case list():
                 return abis
             case _:
@@ -173,8 +184,14 @@ class ERC7730InputToResolved(ERC7730Converter[InputERC7730Descriptor, ResolvedER
     @classmethod
     def _resolve_schema(cls, schema: EIP712JsonSchema | HttpUrl, out: OutputAdder) -> EIP712JsonSchema | None:
         match schema:
-            case HttpUrl():
-                return client.get(schema, EIP712JsonSchema)
+            case HttpUrl() as url:
+                try:
+                    return client.get(url=url, model=EIP712JsonSchema)
+                except Exception as e:
+                    return out.error(
+                        title="Failed to fetch EIP-712 schema from URL",
+                        message=f'Failed to fetch EIP-712 schema from URL "{url}": {e}',
+                    )
             case EIP712JsonSchema():
                 return schema
             case _:

--- a/tests/common/test_client.py
+++ b/tests/common/test_client.py
@@ -1,10 +1,90 @@
-import pytest
+from pydantic_string_url import HttpUrl
 
 from erc7730.common import client
+from erc7730.model.abi import ABI
 
 
-@pytest.mark.skip(reason="Secret management not implemented")
+def test_get_supported_chains() -> None:
+    result = client.get_supported_chains()
+    assert result is not None
+    assert len(result) >= 50
+    names = {chain.chainname for chain in result}
+    assert "Ethereum Mainnet" in names
+    assert "Sepolia Testnet" in names
+    assert "Holesky Testnet" in names
+    assert "BNB Smart Chain Mainnet" in names
+    assert "BNB Smart Chain Testnet" in names
+    assert "Polygon Mainnet" in names
+    assert "Polygon Amoy Testnet" in names
+    assert "Polygon zkEVM Mainnet" in names
+    assert "Polygon zkEVM Cardona Testnet" in names
+    assert "Base Mainnet" in names
+    assert "Base Sepolia Testnet" in names
+    assert "Arbitrum One Mainnet" in names
+    assert "Arbitrum Nova Mainnet" in names
+    assert "Arbitrum Sepolia Testnet" in names
+    assert "Linea Mainnet" in names
+    assert "Linea Sepolia Testnet" in names
+    assert "Fantom Opera Mainnet" in names
+    assert "Fantom Testnet" in names
+    assert "Blast Mainnet" in names
+    assert "Blast Sepolia Testnet" in names
+    assert "OP Mainnet" in names
+    assert "OP Sepolia Testnet" in names
+    assert "Avalanche C-Chain" in names
+    assert "Avalanche Fuji Testnet" in names
+    assert "BitTorrent Chain Mainnet" in names
+    assert "BitTorrent Chain Testnet" in names
+    assert "Celo Mainnet" in names
+    assert "Celo Alfajores Testnet" in names
+    assert "Cronos Mainnet" in names
+    assert "Fraxtal Mainnet" in names
+    assert "Fraxtal Testnet" in names
+    assert "Gnosis" in names
+    assert "Kroma Mainnet" in names
+    assert "Kroma Sepolia Testnet" in names
+    assert "Mantle Mainnet" in names
+    assert "Mantle Sepolia Testnet" in names
+    assert "Moonbeam Mainnet" in names
+    assert "Moonriver Mainnet" in names
+    assert "Moonbase Alpha Testnet" in names
+    assert "opBNB Mainnet" in names
+    assert "opBNB Testnet" in names
+    assert "Scroll Mainnet" in names
+    assert "Scroll Sepolia Testnet" in names
+    assert "Taiko Mainnet" in names
+    assert "Taiko Hekla L2 Testnet" in names
+    assert "WEMIX3.0 Mainnet" in names
+    assert "WEMIX3.0 Testnet" in names
+    assert "zkSync Mainnet" in names
+    assert "zkSync Sepolia Testnet" in names
+    assert "Xai Mainnet" in names
+    assert "Xai Sepolia Testnet" in names
+
+
 def test_get_contract_abis() -> None:
     result = client.get_contract_abis(chain_id=1, contract_address="0x06012c8cf97bead5deae237070f9587f8e7a266d")
     assert result is not None
     assert len(result) > 0
+
+
+def test_get_from_github() -> None:
+    result1 = client.get(
+        url=HttpUrl(
+            "https://github.com/LedgerHQ/ledger-asset-dapps/blob/main"
+            "/ethereum/uniswap/abis/0x000000000022d473030f116ddee9f6b43ac78ba3.abi.json"
+        ),
+        model=list[ABI],
+    )
+    result2 = client.get(
+        url=HttpUrl(
+            "https://raw.githubusercontent.com/LedgerHQ/ledger-asset-dapps/refs/heads/main"
+            "/ethereum/uniswap/abis/0x000000000022d473030f116ddee9f6b43ac78ba3.abi.json"
+        ),
+        model=list[ABI],
+    )
+    assert result1 is not None
+    assert result2 is not None
+    assert len(result1) > 0
+    assert len(result2) > 0
+    assert result1 == result2

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,10 +32,10 @@ def test_schema(model_type: ERC7730ModelType) -> None:
 def test_lint_registry_files(input_file: Path) -> None:
     result = runner.invoke(app, ["lint", str(input_file)])
     out = "".join(result.stdout.splitlines())
-    assert str(input_file) in out
+    assert str(input_file.name) in out
     assert any(
         (
-            "no issues found ✅" in out,
+            "no errors found ✅" in out,
             "some warnings found ⚠️" in out,
             "some errors found ❌" in out,
         )


### PR DESCRIPTION
- only `ETHERSCAN_API_KEY` is required now
- switch client from `requests` to `httpx` (HTTP 2, typed, more easily extensible)
- add disk cache to HTTP client
- add etherscan rate limiting on HTTP client
- add support for `file://` protocol on HTTP client
- improve HTTP client interface to not require `RootModel` anymore

unrelated changes:
 - multithread linter
 - cosmetic/output improvements to linter