### PR TITLE
fix: fix presence of `params` not enforced when parameters are mandatory

### DIFF
--- a/src/erc7730/convert/resolved/convert_erc7730_input_to_resolved.py
+++ b/src/erc7730/convert/resolved/convert_erc7730_input_to_resolved.py
@@ -219,6 +219,26 @@ class ERC7730InputToResolved(ERC7730Converter[InputERC7730Descriptor, ResolvedER
         constants: ConstantProvider,
         out: OutputAdder,
     ) -> ResolvedFieldDescription | None:
+        match definition.format:
+            case None | FieldFormat.RAW | FieldFormat.AMOUNT | FieldFormat.TOKEN_AMOUNT | FieldFormat.DURATION:
+                pass
+            case (
+                FieldFormat.ADDRESS_NAME
+                | FieldFormat.CALL_DATA
+                | FieldFormat.NFT_NAME
+                | FieldFormat.DATE
+                | FieldFormat.UNIT
+                | FieldFormat.ENUM
+            ):
+                if definition.params is None:
+                    return out.error(
+                        title="Missing parameters",
+                        message=f"""Field format "{definition.format.value}" requires parameters to be defined, """
+                        f"""they are missing for field "{definition.path}".""",
+                    )
+            case _:
+                assert_never(definition.format)
+
         params = resolve_field_parameters(prefix, definition.params, enums, constants, out)
 
         if (path := constants.resolve_path(definition.path, out)) is None:


### PR DESCRIPTION
Some formats require parameters to be set, but this is not enforced, leading to invalid resolved descriptors

Registry fixes: https://github.com/LedgerHQ/clear-signing-erc7730-registry/pull/67