### PR TITLE
fix: fix trusted names sources

### DIFF
--- a/src/erc7730/model/display.py
+++ b/src/erc7730/model/display.py
@@ -86,19 +86,6 @@ class AddressNameType(str, Enum):
     """Address is a well known NFT collection."""
 
 
-class AddressNameSources(str, Enum):
-    """
-    Trusted Source for names.
-    """
-
-    LOCAL = "local"
-    """Address MAY be replaced with a local name trusted by user. Wallets MAY consider that local setting for sources
-    is always valid."""
-
-    ENS = "ens"
-    """Address MAY be replaced with an associated ENS domain."""
-
-
 class Screen(RootModel[dict[str, Any]]):
     """
     Screens section is used to group multiple fields to display into screens. Each key is a wallet type name. The

--- a/src/erc7730/model/input/display.py
+++ b/src/erc7730/model/input/display.py
@@ -4,7 +4,6 @@ from pydantic import Discriminator, Field, Tag
 
 from erc7730.model.base import Model
 from erc7730.model.display import (
-    AddressNameSources,
     AddressNameType,
     DateEncoding,
     FieldFormat,
@@ -105,11 +104,11 @@ class InputAddressNameParameters(Model):
         min_length=1,
     )
 
-    sources: list[AddressNameSources] | DescriptorPathStr | None = Field(
+    sources: list[str] | DescriptorPathStr | None = Field(
         default=None,
         title="Trusted Sources",
-        description="An array of acceptable sources for names (see next section). If set, the wallet SHOULD restrict "
-        "name lookup to relevant sources.",
+        description="An array of acceptable sources for names. If set, the wallet SHOULD restrict name lookup to "
+        "relevant sources.",
         min_length=1,
     )
 

--- a/src/erc7730/model/resolved/display.py
+++ b/src/erc7730/model/resolved/display.py
@@ -5,7 +5,6 @@ from pydantic import Discriminator, Field, Tag
 
 from erc7730.model.base import Model
 from erc7730.model.display import (
-    AddressNameSources,
     AddressNameType,
     DateEncoding,
     FieldFormat,
@@ -66,11 +65,11 @@ class ResolvedAddressNameParameters(Model):
         min_length=1,
     )
 
-    sources: list[AddressNameSources] | None = Field(
+    sources: list[str] | None = Field(
         default=None,
         title="Trusted Sources",
-        description="An array of acceptable sources for names (see next section). If set, the wallet SHOULD restrict "
-        "name lookup to relevant sources.",
+        description="An array of acceptable sources for names. If set, the wallet SHOULD restrict name lookup to "
+        "relevant sources.",
         min_length=1,
     )
 


### PR DESCRIPTION
`sources` are now free form strings since https://github.com/LedgerHQ/clear-signing-erc7730-registry/pull/23

