### PR TITLE
fix: fix default console output not printing file path

### DIFF
--- a/src/erc7730/common/output.py
+++ b/src/erc7730/common/output.py
@@ -111,8 +111,12 @@ class ConsoleOutputAdder(OutputAdder):
                 assert_never(output.level)
 
         log = f"[{style}]{prefix}"
+        context = []
+        if output.file is not None:
+            context.append(f"{output.file}")
         if output.line is not None:
-            log += f"line {output.line}: "
+            context.append(f"line {output.line}")
+        log += ", ".join(context)
         if output.title is not None:
             log += f"{output.title}: "
         log += f"[/{style}]{output.message}"
@@ -176,7 +180,7 @@ class GithubAnnotationsAdder(OutputAdder):
         builtin_print(log)
 
 
-class FileOutputAdder(OutputAdder):
+class AddFileOutputAdder(OutputAdder):
     """An output adder wrapper that adds a specific file to all outputs."""
 
     def __init__(self, delegate: OutputAdder, file: FilePath) -> None:
@@ -188,6 +192,19 @@ class FileOutputAdder(OutputAdder):
     def add(self, output: Output) -> None:
         super().add(output)
         self.delegate.add(output.model_copy(update={"file": self.file}))
+
+
+class DropFileOutputAdder(OutputAdder):
+    """An output adder wrapper that drops file information from all outputs."""
+
+    def __init__(self, delegate: OutputAdder) -> None:
+        super().__init__()
+        self.delegate: OutputAdder = delegate
+
+    @override
+    def add(self, output: Output) -> None:
+        super().add(output)
+        self.delegate.add(output.model_copy(update={"file": None}))
 
 
 @final

--- a/src/erc7730/lint/lint.py
+++ b/src/erc7730/lint/lint.py
@@ -7,7 +7,14 @@ from pydantic import ValidationError
 from rich import print
 
 from erc7730 import ERC_7730_REGISTRY_CALLDATA_PREFIX, ERC_7730_REGISTRY_EIP712_PREFIX
-from erc7730.common.output import BufferAdder, ConsoleOutputAdder, FileOutputAdder, GithubAnnotationsAdder, OutputAdder
+from erc7730.common.output import (
+    AddFileOutputAdder,
+    BufferAdder,
+    ConsoleOutputAdder,
+    DropFileOutputAdder,
+    GithubAnnotationsAdder,
+    OutputAdder,
+)
 from erc7730.convert.resolved.convert_erc7730_input_to_resolved import ERC7730InputToResolved
 from erc7730.lint import ERC7730Linter
 from erc7730.lint.lint_base import MultiLinter
@@ -18,7 +25,7 @@ from erc7730.model.input.descriptor import InputERC7730Descriptor
 
 
 def lint_all_and_print_errors(paths: list[Path], gha: bool = False) -> bool:
-    out = GithubAnnotationsAdder() if gha else ConsoleOutputAdder()
+    out = GithubAnnotationsAdder() if gha else DropFileOutputAdder(delegate=ConsoleOutputAdder())
 
     count = lint_all(paths, out)
 
@@ -91,7 +98,7 @@ def lint_file(path: Path, linter: ERC7730Linter, out: OutputAdder, show_as: Path
     """
 
     label = path if show_as is None else show_as
-    file_out = FileOutputAdder(delegate=out, file=path)
+    file_out = AddFileOutputAdder(delegate=out, file=path)
 
     with BufferAdder(file_out, prolog=f"➡️ checking [bold]{label}[/bold]…", epilog="") as out:
         try:


### PR DESCRIPTION
we want:
 - default console output adder to print file paths (used in CAL)
 - `lint` to not print it (it uses sections)
 - `lint --gha` to print it

