### PR TITLE
feat(BACK-7910): implement handling of nested fields

### DIFF
--- a/docs/pages/usage_library.md
+++ b/docs/pages/usage_library.md
@@ -46,6 +46,7 @@ Descriptors can be manipulated in 2 forms:
     - References have been inlined
     - Constants have been inlined
     - Field definitions have been inlined
+    - Nested fields have been flattened where possible
     - Selectors have been converted to 4 bytes form
    This form is the most adapted to be used by tools and applications.
 

--- a/src/erc7730/main.py
+++ b/src/erc7730/main.py
@@ -84,6 +84,7 @@ def lint(
         - References inlined
         - Constants inlined
         - Field definitions inlined
+        - Nested fields flattened where possible
         - Selectors converted to 4 bytes form
     
     See `erc7730 schema resolved` for the resolved descriptor schema.

--- a/src/erc7730/model/input/descriptor.py
+++ b/src/erc7730/model/input/descriptor.py
@@ -7,6 +7,7 @@ This model represents descriptors before resolution phase:
     - References have not been inlined
     - Constants have not been inlined
     - Field definitions have not been inlined
+    - Nested fields have been flattened where possible
     - Selectors have been converted to 4 bytes form
 """
 

--- a/src/erc7730/model/resolved/__init__.py
+++ b/src/erc7730/model/resolved/__init__.py
@@ -7,5 +7,6 @@ This model represents descriptors after resolution phase:
     - References have been inlined
     - Constants have been inlined
     - Field definitions have been inlined
+    - Nested fields have been flattened where possible
     - Selectors have been converted to 4 bytes form
 """

--- a/src/erc7730/model/resolved/descriptor.py
+++ b/src/erc7730/model/resolved/descriptor.py
@@ -7,6 +7,7 @@ This model represents descriptors after resolution phase:
     - References have been inlined
     - Constants have been inlined
     - Field definitions have been inlined
+    - Nested fields have been flattened where possible
     - Selectors have been converted to 4 bytes form
 """
 
@@ -30,6 +31,7 @@ class ResolvedERC7730Descriptor(Model):
         - References have been inlined
         - Constants have been inlined
         - Field definitions have been inlined
+        - Nested fields have been flattened where possible
         - Selectors have been converted to 4 bytes form
 
     Specification: https://github.com/LedgerHQ/clear-signing-erc7730-registry/tree/master/specs

--- a/tests/convert/resolved/data/nested_fields_eip712_array_input.json
+++ b/tests/convert/resolved/data/nested_fields_eip712_array_input.json
@@ -1,0 +1,74 @@
+{
+    "$schema": "../../../registries/clear-signing-erc7730-registry/specs/erc7730-v1.schema.json",
+    "context": {
+        "eip712": {
+            "deployments": [
+                {
+                    "chainId": 1,
+                    "address": "0x0000000000000000000000000000000000000000"
+                }
+            ],
+            "schemas": [
+                {
+                    "primaryType": "TestPrimaryType",
+                    "types": {
+                        "EIP712Domain": [
+                            {
+                                "name": "name",
+                                "type": "string"
+                            },
+                            {
+                                "name": "chainId",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "verifyingContract",
+                                "type": "address"
+                            }
+                        ],
+                        "TestSubtype": [
+                            {
+                                "name": "subparam1",
+                                "type": "string"
+                            },
+                            {
+                                "name": "subparam2",
+                                "type": "string"
+                            }
+                        ],
+                        "TestPrimaryType": [
+                            {
+                                "name": "param1",
+                                "type": "TestSubtype[]"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {},
+    "display": {
+        "formats": {
+            "TestPrimaryType": {
+                "fields": [
+                    {
+                        "path": "param1.[]",
+                        "fields": [
+                            {
+                                "path": "subparam1",
+                                "label": "Subparam 1",
+                                "format": "raw"
+                            },
+                            {
+                                "path": "subparam2",
+                                "label": "Subparam 2",
+                                "format": "raw"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/convert/resolved/data/nested_fields_eip712_array_resolved.json
+++ b/tests/convert/resolved/data/nested_fields_eip712_array_resolved.json
@@ -1,0 +1,53 @@
+{
+  "context": {
+    "eip712": {
+      "deployments": [{ "chainId": 1, "address": "0x0000000000000000000000000000000000000000" }],
+      "schemas": [
+        {
+          "primaryType": "TestPrimaryType",
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "TestSubtype": [{ "name": "subparam1", "type": "string" }, { "name": "subparam2", "type": "string" }],
+            "TestPrimaryType": [{ "name": "param1", "type": "TestSubtype[]" }]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": { "enums": {} },
+  "display": {
+    "formats": {
+      "TestPrimaryType": {
+        "fields": [
+          {
+            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }, { "type": "array" }] },
+            "fields": [
+              {
+                "path": {
+                  "type": "data",
+                  "absolute": true,
+                  "elements": [{ "type": "field", "identifier": "param1" }, { "type": "array" }, { "type": "field", "identifier": "subparam1" }]
+                },
+                "label": "Subparam 1",
+                "format": "raw"
+              },
+              {
+                "path": {
+                  "type": "data",
+                  "absolute": true,
+                  "elements": [{ "type": "field", "identifier": "param1" }, { "type": "array" }, { "type": "field", "identifier": "subparam2" }]
+                },
+                "label": "Subparam 2",
+                "format": "raw"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/convert/resolved/data/nested_fields_eip712_struct_input.json
+++ b/tests/convert/resolved/data/nested_fields_eip712_struct_input.json
@@ -1,0 +1,74 @@
+{
+    "$schema": "../../../registries/clear-signing-erc7730-registry/specs/erc7730-v1.schema.json",
+    "context": {
+        "eip712": {
+            "deployments": [
+                {
+                    "chainId": 1,
+                    "address": "0x0000000000000000000000000000000000000000"
+                }
+            ],
+            "schemas": [
+                {
+                    "primaryType": "TestPrimaryType",
+                    "types": {
+                        "EIP712Domain": [
+                            {
+                                "name": "name",
+                                "type": "string"
+                            },
+                            {
+                                "name": "chainId",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "verifyingContract",
+                                "type": "address"
+                            }
+                        ],
+                        "TestSubtype": [
+                            {
+                                "name": "subparam1",
+                                "type": "string"
+                            },
+                            {
+                                "name": "subparam2",
+                                "type": "string"
+                            }
+                        ],
+                        "TestPrimaryType": [
+                            {
+                                "name": "param1",
+                                "type": "TestSubtype"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {},
+    "display": {
+        "formats": {
+            "TestPrimaryType": {
+                "fields": [
+                    {
+                        "path": "param1",
+                        "fields": [
+                            {
+                                "path": "subparam1",
+                                "label": "Subparam 1",
+                                "format": "raw"
+                            },
+                            {
+                                "path": "subparam2",
+                                "label": "Subparam 2",
+                                "format": "raw"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/tests/convert/resolved/data/nested_fields_eip712_struct_resolved.json
+++ b/tests/convert/resolved/data/nested_fields_eip712_struct_resolved.json
@@ -1,0 +1,48 @@
+{
+  "context": {
+    "eip712": {
+      "deployments": [{ "chainId": 1, "address": "0x0000000000000000000000000000000000000000" }],
+      "schemas": [
+        {
+          "primaryType": "TestPrimaryType",
+          "types": {
+            "EIP712Domain": [
+              { "name": "name", "type": "string" },
+              { "name": "chainId", "type": "uint256" },
+              { "name": "verifyingContract", "type": "address" }
+            ],
+            "TestSubtype": [{ "name": "subparam1", "type": "string" }, { "name": "subparam2", "type": "string" }],
+            "TestPrimaryType": [{ "name": "param1", "type": "TestSubtype" }]
+          }
+        }
+      ]
+    }
+  },
+  "metadata": { "enums": {} },
+  "display": {
+    "formats": {
+      "TestPrimaryType": {
+        "fields": [
+          {
+            "path": {
+              "type": "data",
+              "absolute": true,
+              "elements": [{ "type": "field", "identifier": "param1" }, { "type": "field", "identifier": "subparam1" }]
+            },
+            "label": "Subparam 1",
+            "format": "raw"
+          },
+          {
+            "path": {
+              "type": "data",
+              "absolute": true,
+              "elements": [{ "type": "field", "identifier": "param1" }, { "type": "field", "identifier": "subparam2" }]
+            },
+            "label": "Subparam 2",
+            "format": "raw"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/convert/resolved/test_convert_input_to_resolved.py
+++ b/tests/convert/resolved/test_convert_input_to_resolved.py
@@ -253,6 +253,16 @@ def test_registry_files(input_file: Path) -> None:
             description="use of a valid reference to a valid display definition, with invalid overrides",
             error="Extra inputs are not permitted",
         ),
+        TestCase(
+            id="nested_fields_eip712_array",
+            label="nested fields - array parameter (EIP-712 descriptor)",
+            description="use of nested fields on an array parameter (EIP-712 descriptor)",
+        ),
+        TestCase(
+            id="nested_fields_eip712_struct",
+            label="nested fields - struct parameter (EIP-712 descriptor)",
+            description="use of nested fields on a struct parameter (EIP-712 descriptor)",
+        ),
     ],
     ids=case_id,
 )


### PR DESCRIPTION
During resolution, nested fields are:
 - flattened if path points to a struct or array element
 - preserved if path points to an array
 - forbidden if path points to an array slice

