### PR TITLE
feat(BACK-7924): improve error handling

### DIFF
--- a/src/erc7730/common/pydantic.py
+++ b/src/erc7730/common/pydantic.py
@@ -1,9 +1,12 @@
 import json
 import os
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, LiteralString, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationInfo, WrapValidator
+from pydantic_core import PydanticCustomError
 
 from erc7730.common.json import CompactJSONEncoder, read_json_with_includes
 
@@ -46,3 +49,26 @@ def model_to_json_file(path: Path, model: _BaseModel) -> None:
     with open(path, "w") as f:
         f.write(model_to_json_str(model))
         f.write("\n")
+
+
+@dataclass(frozen=True)
+class ErrorTypeLabel(WrapValidator):
+    """
+    Wrapper validator that replaces all errors with a simple message "expected a <type label>".
+
+    It is useful for annotating union types where pydantic returns multiple errors for each type it tries, or custom
+    base types such as pattern validated strings to get more user-friendly errors.
+    """
+
+    def __init__(self, type_label: LiteralString) -> None:
+        super().__init__(self._validator(type_label))
+
+    @staticmethod
+    def _validator(type_label: LiteralString) -> Callable[[Any, Any, ValidationInfo], Any]:
+        def validate(v: Any, next_: Any, ctx: ValidationInfo) -> Any:
+            try:
+                return next_(v, ctx)
+            except Exception:
+                raise PydanticCustomError("custom_error", "expected a " + type_label) from None
+
+        return validate

--- a/src/erc7730/convert/resolved/references.py
+++ b/src/erc7730/convert/resolved/references.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any
 
-from pydantic import TypeAdapter, ValidationError
+from pydantic import TypeAdapter
 
 from erc7730.common.options import first_not_none
 from erc7730.common.output import OutputAdder
@@ -56,15 +56,9 @@ def resolve_reference(
     resolved_params: ResolvedFieldParameters | None = None
 
     if params:
-        try:
-            input_params: InputFieldParameters = TypeAdapter(InputFieldParameters).validate_json(json.dumps(params))
-            if (resolved_params := resolve_field_parameters(prefix, input_params, enums, constants, out)) is None:
-                return None
-        except ValidationError as e:
-            return out.error(
-                title="Invalid display field parameters",
-                message=f"Error parsing display field parameters: {e}",
-            )
+        input_params: InputFieldParameters = TypeAdapter(InputFieldParameters).validate_json(json.dumps(params))
+        if (resolved_params := resolve_field_parameters(prefix, input_params, enums, constants, out)) is None:
+            return None
 
     if (path := constants.resolve_path(reference.path, out)) is None:
         return None

--- a/src/erc7730/lint/lint_validate_abi.py
+++ b/src/erc7730/lint/lint_validate_abi.py
@@ -1,7 +1,5 @@
 from typing import final, override
 
-from pydantic import ValidationError
-
 from erc7730.common import client
 from erc7730.common.abi import compute_signature, get_functions
 from erc7730.common.output import OutputAdder
@@ -41,7 +39,7 @@ class ValidateABILinter(ERC7730Linter):
             try:
                 if (abis := client.get_contract_abis(deployment.chainId, deployment.address)) is None:
                     continue
-            except ValidationError as e:
+            except Exception as e:
                 out.warning(
                     title="Could not fetch ABI",
                     message=f"Fetching reference ABI for chain id {deployment.chainId} failed, descriptor ABIs will "

--- a/src/erc7730/lint/lint_validate_display_fields.py
+++ b/src/erc7730/lint/lint_validate_display_fields.py
@@ -42,12 +42,12 @@ class ValidateDisplayFieldsLinter(ERC7730Linter):
                         out.error(
                             title="Invalid EIP712 Schema",
                             message=f"Primary type `{schema.primaryType}` is not present in schema types. Please make "
-                            f"sure the EIP-712 includes a definition for the primary type.",
+                            f"sure the EIP-712 schema includes a definition for the primary type.",
                         )
                         continue
                     if schema.primaryType not in descriptor.display.formats:
                         out.error(
-                            title="Missing Display field",
+                            title="Missing Display Format",
                             message=f"Schema primary type `{schema.primaryType}` must have a display format defined.",
                         )
                         continue
@@ -67,22 +67,23 @@ class ValidateDisplayFieldsLinter(ERC7730Linter):
                         if any(data_path_ends_with(path, allowed) for allowed in AUTHORIZED_MISSING_DISPLAY_FIELDS):
                             out.debug(
                                 title="Optional Display field missing",
-                                message=f"Display field for path `{path}` is missing for message {schema.primaryType}. "
-                                f"If intentionally excluded, please add it to `excluded` list to avoid this "
-                                f"warning.",
+                                message=f"No display field is defined for path `{path}` in message "
+                                f"{schema.primaryType}. If intentionally excluded, please add it to `excluded` "
+                                f"list to avoid this warning.",
                             )
                         else:
                             out.warning(
                                 title="Missing Display field",
-                                message=f"Display field for path `{path}` is missing for message {schema.primaryType}. "
+                                message=f"No display field is defined for path `{path}` in {schema.primaryType}. "
                                 f"If intentionally excluded, please add it to `excluded` list to avoid this "
                                 f"warning.",
                             )
                     for path in format_paths - eip712_paths:
                         out.error(
-                            title="Extra Display field",
-                            message=f"Display field for path `{path}` is not in message {schema.primaryType}. Please "
-                            f"check the field path is valid according to the EIP-712 schema.",
+                            title="Invalid Display field",
+                            message=f"A display field is defined for `{path}`, but it does not exist in message "
+                            f"{schema.primaryType}. Please check the field path is valid according to the EIP-712 "
+                            f"schema.",
                         )
 
                 else:
@@ -94,9 +95,9 @@ class ValidateDisplayFieldsLinter(ERC7730Linter):
             for fmt in descriptor.display.formats:
                 if fmt not in primary_types:
                     out.error(
-                        title="Invalid Display field",
-                        message=f"Format message `{fmt}` is not in EIP712 schemas. Please check the field path is "
-                        f"valid according to the EIP-712 schema.",
+                        title="Invalid Display Format",
+                        message=f"Type `{fmt}` is not in EIP712 schemas. Please check the type is valid according to "
+                        f"the EIP-712 schema.",
                     )
 
     @classmethod
@@ -128,18 +129,19 @@ class ValidateDisplayFieldsLinter(ERC7730Linter):
 
                     if any(data_path_ends_with(path, allowed) for allowed in AUTHORIZED_MISSING_DISPLAY_FIELDS):
                         out.debug(
-                            title="Optional Display field missing",
-                            message=f"Display field for path `{path}` is missing for selector {selector}. If "
+                            title="Optional Display Field Missing",
+                            message=f"No display field is defined for path `{path}` in function {selector}. If "
                             f"intentionally excluded, please add it to `excluded` list to avoid this warning.",
                         )
                     else:
                         out.warning(
                             title="Missing Display field",
-                            message=f"Display field for path `{path}` is missing for selector {selector}. If "
+                            message=f"No display field is defined for path `{path}` in function {selector}. If "
                             f"intentionally excluded, please add it to `excluded` list to avoid this warning.",
                         )
                 for path in format_paths - abi_paths:
                     out.error(
                         title="Invalid Display field",
-                        message=f"Display field for path `{path}` is not in selector {selector}.",
+                        message=f"A display field is defined for `{path}`, but it does not exist in function "
+                        f"{selector} ABI. Please check the field path is valid according to the ABI.",
                     )

--- a/src/erc7730/model/display.py
+++ b/src/erc7730/model/display.py
@@ -99,6 +99,8 @@ SimpleIntent = Annotated[
     Field(
         title="Simple Intent",
         description="A description of the intent of the structured data signing, that will be displayed to the user.",
+        min_length=1,
+        max_length=256,  # TODO: arbitrary value, to be refined
     ),
 ]
 
@@ -107,6 +109,8 @@ ComplexIntent = Annotated[
     Field(
         title="Complex Intent",
         description="A description of the intent of the structured data signing, that will be displayed to the user.",
+        min_length=1,
+        max_length=32,  # TODO: arbitrary value, to be refined
     ),
 ]
 

--- a/src/erc7730/model/input/display.py
+++ b/src/erc7730/model/input/display.py
@@ -70,11 +70,13 @@ class InputTokenAmountParameters(Model):
         '"Unknown token" warning.',
     )
 
-    nativeCurrencyAddress: DescriptorPathStr | list[MixedCaseAddress] | MixedCaseAddress | None = Field(
-        default=None,
-        title="Native Currency Address",
-        description="An address or array of addresses, any of which are interpreted as an amount in native currency "
-        "rather than a token.",
+    nativeCurrencyAddress: list[DescriptorPathStr | MixedCaseAddress] | DescriptorPathStr | MixedCaseAddress | None = (
+        Field(
+            default=None,
+            title="Native Currency Address",
+            description="An address or array of addresses, any of which are interpreted as an amount in native "
+            "currency rather than a token.",
+        )
     )
 
     threshold: DescriptorPathStr | HexStr | int | None = Field(

--- a/src/erc7730/model/input/path.py
+++ b/src/erc7730/model/input/path.py
@@ -12,6 +12,7 @@ from pydantic_core.core_schema import (
     to_string_ser_schema,
 )
 
+from erc7730.common.pydantic import ErrorTypeLabel
 from erc7730.model.paths import ContainerPath, DataPath, DescriptorPath
 from erc7730.model.paths.path_parser import to_path
 
@@ -30,6 +31,9 @@ ContainerPathStr = Annotated[
         title="Input Path",
         description="A path applying to the container of the structured data to be signed. Such paths are prefixed "
         """with "@".""",
+    ),
+    ErrorTypeLabel(
+        "path applying to the container of the structured data to be signed, such as " + '"@.to" or "@.value".'
     ),
 ]
 
@@ -50,6 +54,7 @@ DataPathStr = Annotated[
         "itself for EIP-712). A data path can reference multiple values if it contains array elements or slices. Such "
         """paths are prefixed with "#".""",
     ),
+    ErrorTypeLabel("data path referencing a value in the structured data schema, such as " + '"#.foo.[0].bar.[0:-1]".'),
 ]
 
 DESCRIPTOR_PATH_STR_JSON_SCHEMA = chain_schema(
@@ -68,5 +73,10 @@ DescriptorPathStr = Annotated[
         description="A path applying to the current file describing the structured data formatting, after merging "
         "with includes. A descriptor path can only reference a single value in the document. Such paths are prefixed "
         """with "$".""",
+        examples=["$.foo.bar"],
+    ),
+    ErrorTypeLabel(
+        "descriptor path referencing a value in the descriptor document using jsonpath syntax, such as "
+        + '"$.foo.bar".'
     ),
 ]

--- a/src/erc7730/model/types.py
+++ b/src/erc7730/model/types.py
@@ -9,14 +9,18 @@ from typing import Annotated
 
 from pydantic import BeforeValidator, Field
 
+from erc7730.common.pydantic import ErrorTypeLabel
+
 Id = Annotated[
     str,
     Field(
         title="Id",
-        description="An internal identifier that can be used either for clarity specifying what the element is or as a"
+        description="An internal identifier that can be used either for clarity specifying what the element is or as a "
         "reference in device specific sections.",
         min_length=1,
+        examples=["some_identifier"],
     ),
+    ErrorTypeLabel('identifier, such as "some_identifier".'),
 ]
 
 MixedCaseAddress = Annotated[
@@ -27,6 +31,10 @@ MixedCaseAddress = Annotated[
         min_length=42,
         max_length=42,
         pattern=r"^0x[a-fA-F0-9]+$",
+    ),
+    ErrorTypeLabel(
+        '20 bytes, hexadecimal Ethereum address prefixed with "0x" (EIP-55 or lowercase), such as '
+        + '"0xdac17f958d2ee523a2206206994597c13d831ec7".'
     ),
 ]
 
@@ -40,6 +48,10 @@ Address = Annotated[
         pattern=r"^0x[a-f0-9]+$",
     ),
     BeforeValidator(lambda v: v.lower()),
+    ErrorTypeLabel(
+        '20 bytes, lowercase hexadecimal Ethereum address prefixed with "0x", such as '
+        + '"0xdac17f958d2ee523a2206206994597c13d831ec7".'
+    ),
 ]
 
 Selector = Annotated[
@@ -51,6 +63,9 @@ Selector = Annotated[
         max_length=10,
         pattern=r"^0x[a-z0-9]+$",
     ),
+    ErrorTypeLabel(
+        '4 bytes, lowercase hexadecimal Ethereum function selector prefixed with "0x", such as ' + '"0xdac17f95".'
+    ),
 ]
 
 HexStr = Annotated[
@@ -61,6 +76,7 @@ HexStr = Annotated[
         pattern=r"^0x[a-f0-9]+$",
     ),
     BeforeValidator(lambda v: v.lower()),
+    ErrorTypeLabel('lowercase hexadecimal string prefixed with "0x", such as "0xdac17f95".'),
 ]
 
 ScalarType = str | int | bool | float

--- a/tests/convert/resolved/data/definition_format_nft_name_resolved.json
+++ b/tests/convert/resolved/data/definition_format_nft_name_resolved.json
@@ -11,7 +11,7 @@
               { "name": "chainId", "type": "uint256" },
               { "name": "verifyingContract", "type": "address" }
             ],
-            "TestPrimaryType": [{ "name": "param1", "type": "string" }]
+            "TestPrimaryType": [{ "name": "param1", "type": "string" }, { "name": "collection1", "type": "address" }]
           }
         }
       ]
@@ -26,13 +26,7 @@
             "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
             "label": "Param 1",
             "format": "nftName",
-            "params": {
-              "collectionPath": {
-                "type": "data",
-                "absolute": true,
-                "elements": [{ "type": "field", "identifier": "0x0000000000000000000000000000000000000001" }]
-              }
-            }
+            "params": { "collectionPath": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "collection1" }] } }
           }
         ]
       }

--- a/tests/convert/resolved/data/unsupported_using_literal_values_as_constants_input.json
+++ b/tests/convert/resolved/data/unsupported_using_literal_values_as_constants_input.json
@@ -32,7 +32,7 @@
                                 "type": "string"
                             },
                             {
-                                "name": "collection1",
+                                "name": "token1",
                                 "type": "address"
                             }
                         ]
@@ -41,23 +41,22 @@
             ]
         }
     },
-    "metadata": {},
+    "metadata": {
+        "constants": {
+            "token_path": "0x0000000000000000000000000000000000000001"
+        }
+    },
     "display": {
-        "definitions": {
-            "test_definition": {
-                "label": "Param 1",
-                "format": "nftName",
-                "params": {
-                    "collectionPath": "collection1"
-                }
-            }
-        },
         "formats": {
             "TestPrimaryType": {
                 "fields": [
                     {
-                        "path": "param1",
-                        "$ref": "$.display.definitions.test_definition"
+                        "path": "#.param1",
+                        "label": "Param 1",
+                        "format": "tokenAmount",
+                        "params": {
+                            "tokenPath": "$.metadata.constants.token_path"
+                        }
                     }
                 ]
             }

--- a/tests/convert/resolved/data/unsupported_using_literal_values_input.json
+++ b/tests/convert/resolved/data/unsupported_using_literal_values_input.json
@@ -32,7 +32,7 @@
                                 "type": "string"
                             },
                             {
-                                "name": "collection1",
+                                "name": "token1",
                                 "type": "address"
                             }
                         ]
@@ -43,21 +43,16 @@
     },
     "metadata": {},
     "display": {
-        "definitions": {
-            "test_definition": {
-                "label": "Param 1",
-                "format": "nftName",
-                "params": {
-                    "collectionPath": "collection1"
-                }
-            }
-        },
         "formats": {
             "TestPrimaryType": {
                 "fields": [
                     {
-                        "path": "param1",
-                        "$ref": "$.display.definitions.test_definition"
+                        "path": "#.param1",
+                        "label": "Param 1",
+                        "format": "tokenAmount",
+                        "params": {
+                            "tokenPath": "0x0000000000000000000000000000000000000001"
+                        }
                     }
                 ]
             }

--- a/tests/convert/resolved/test_convert_input_to_resolved.py
+++ b/tests/convert/resolved/test_convert_input_to_resolved.py
@@ -213,13 +213,13 @@ def test_registry_files(input_file: Path) -> None:
             id="definition_invalid_container_path",
             label="display definition / reference - using a container path",
             description="use of a reference to a display definition with a container path",
-            error="Input should be an instance of DescriptorPath",
+            error="descriptor path referencing a value in the descriptor document using jsonpath syntax, such as",
         ),
         TestCase(
             id="definition_invalid_data_path",
             label="display definition / reference - using a data path",
             description="use of a reference to a display definition with a data path",
-            error="Input should be an instance of DescriptorPath",
+            error="descriptor path referencing a value in the descriptor document using jsonpath syntax, such as",
         ),
         TestCase(
             id="definition_invalid_path_does_not_exist",
@@ -263,12 +263,24 @@ def test_registry_files(input_file: Path) -> None:
             label="nested fields - struct parameter (EIP-712 descriptor)",
             description="use of nested fields on a struct parameter (EIP-712 descriptor)",
         ),
+        TestCase(
+            id="unsupported_using_literal_values",
+            label="unsupported: using literal value instead of data path",
+            description="using a literal value where a data path is expected",
+            error="It seems you are trying to use a constant address value instead",
+        ),
+        TestCase(
+            id="unsupported_using_literal_values_as_constants",
+            label="unsupported: using literal value instead of data path",
+            description="using a literal value where a data path is expected, defined in constants section",
+            error="It seems you are trying to use a constant address value instead",
+        ),
     ],
     ids=case_id,
 )
 def test_by_reference(testcase: TestCase) -> None:
     """
-    Test converting ERC-7730 registry files from input to resolved form, and compare against reference files.
+    Test converting ERC-7730 descriptor files from input to resolved form, and compare against reference files.
     """
     input_descriptor_path = DATA / f"{testcase.id}_input.json"
     resolved_descriptor_path = DATA / f"{testcase.id}_resolved.json"

--- a/tests/model/data/errors/format_token_amount_native_currency_address_using_data_path.json
+++ b/tests/model/data/errors/format_token_amount_native_currency_address_using_data_path.json
@@ -32,7 +32,7 @@
                                 "type": "string"
                             },
                             {
-                                "name": "collection1",
+                                "name": "token1",
                                 "type": "address"
                             }
                         ]
@@ -43,21 +43,17 @@
     },
     "metadata": {},
     "display": {
-        "definitions": {
-            "test_definition": {
-                "label": "Param 1",
-                "format": "nftName",
-                "params": {
-                    "collectionPath": "collection1"
-                }
-            }
-        },
         "formats": {
             "TestPrimaryType": {
                 "fields": [
                     {
-                        "path": "param1",
-                        "$ref": "$.display.definitions.test_definition"
+                        "path": "#.param1",
+                        "label": "Param 1",
+                        "format": "tokenAmount",
+                        "params": {
+                            "tokenPath": "#.token1",
+                            "nativeCurrencyAddress": "#.foo.bar"
+                        }
                     }
                 ]
             }

--- a/tests/model/test_model_validation.py
+++ b/tests/model/test_model_validation.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+
+from erc7730.common.output import ExceptionsToOutput, SetOutputAdder
+from erc7730.model.input.descriptor import InputERC7730Descriptor
+from tests.cases import TestCase, case_id
+
+DATA = Path(__file__).resolve().parent / "data"
+
+
+@pytest.mark.parametrize(
+    "testcase",
+    [
+        TestCase(
+            id="format_token_amount_native_currency_address_using_data_path",
+            label="using a data path where an address value is expected",
+            description="using a literal value where a data path is expected",
+            error="expected a 20 bytes, hexadecimal Ethereum address",
+        ),
+    ],
+    ids=case_id,
+)
+def test_errors_by_reference(testcase: TestCase) -> None:
+    """
+    Test loading and validating and erroneous ERC-7730 descriptor files, and compare against expected errors.
+    """
+    input_descriptor_path = DATA / "errors" / f"{testcase.id}.json"
+    if (expected_error := testcase.error) is None:
+        pytest.fail("Testcase must have an expected error")
+    out = SetOutputAdder()
+    with ExceptionsToOutput(out):
+        InputERC7730Descriptor.load(input_descriptor_path)
+    messages = {output.message for output in out.outputs}
+    assert any(expected_error in message for message in messages), "Expected error not found in:\n" + "\n".join(
+        messages
+    )


### PR DESCRIPTION
- improve output for some particular errors (HTTP responses, addresses used instead of paths)
- sanitize pydantic errors
- customize errors for specific types (path, base types, unions)
- sort and deduplicate linter outputs
- minor wording improvements

This fixes bad error output in https://github.com/LedgerHQ/clear-signing-erc7730-registry/pull/33