### PR TITLE
feat(BACK-8135): add support for constant values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         name: sync pre-commit dependencies
 
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.19.2
+    rev: 2.21.0
     hooks:
       - id: pdm-lock-check
         name: check pdm lock file
@@ -72,7 +72,7 @@ repos:
         name: apply walrus operator
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.8.2
     hooks:
       - id: ruff
         name: lint code (ruff)
@@ -93,8 +93,8 @@ repos:
           - types-requests
           - types-setuptools
           - types-protobuf
-          - pydantic==2.9.2
-          - pytest==8.3.3
+          - pydantic==2.10.3
+          - pytest==8.3.4
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.8

--- a/src/erc7730/common/properties.py
+++ b/src/erc7730/common/properties.py
@@ -1,6 +1,17 @@
 from typing import Any
 
 
+def has_any_property(target: Any, *names: str) -> bool:
+    """
+    Check if the target has a property with any of the given names.
+
+    :param target: object of dict like
+    :param names: attribute names
+    :return: true if the target has the property
+    """
+    return any(has_property(target, n) for n in names)
+
+
 def has_property(target: Any, name: str) -> bool:
     """
     Check if the target has a property with the given name.

--- a/src/erc7730/convert/resolved/convert_erc7730_input_to_resolved.py
+++ b/src/erc7730/convert/resolved/convert_erc7730_input_to_resolved.py
@@ -10,6 +10,7 @@ from erc7730.convert import ERC7730Converter
 from erc7730.convert.resolved.constants import ConstantProvider, DefaultConstantProvider
 from erc7730.convert.resolved.parameters import resolve_field_parameters
 from erc7730.convert.resolved.references import resolve_reference
+from erc7730.convert.resolved.values import resolve_value
 from erc7730.model.abi import ABI
 from erc7730.model.context import EIP712Schema
 from erc7730.model.display import (
@@ -37,7 +38,7 @@ from erc7730.model.input.display import (
 from erc7730.model.input.metadata import InputMetadata
 from erc7730.model.metadata import EnumDefinition
 from erc7730.model.paths import ROOT_DATA_PATH, Array, ArrayElement, ArraySlice, ContainerPath, DataPath, Field
-from erc7730.model.paths.path_ops import data_or_container_path_concat, data_path_concat
+from erc7730.model.paths.path_ops import data_path_concat
 from erc7730.model.resolved.context import (
     ResolvedContract,
     ResolvedContractContext,
@@ -54,6 +55,7 @@ from erc7730.model.resolved.display import (
     ResolvedFieldDescription,
     ResolvedFormat,
     ResolvedNestedFields,
+    ResolvedValuePath,
 )
 from erc7730.model.resolved.metadata import ResolvedMetadata
 from erc7730.model.types import Address, Id, Selector
@@ -312,13 +314,13 @@ class ERC7730InputToResolved(ERC7730Converter[InputERC7730Descriptor, ResolvedER
 
         params = resolve_field_parameters(prefix, definition.params, enums, constants, out)
 
-        if (path := constants.resolve_path(definition.path, out)) is None:
+        if (value := resolve_value(prefix, definition, constants, out)) is None:
             return None
 
         return ResolvedFieldDescription.model_validate(
             {
                 "$id": definition.id,
-                "path": data_or_container_path_concat(prefix, path),
+                "value": value,
                 "label": constants.resolve(definition.label, out),
                 "format": FieldFormat(definition.format) if definition.format is not None else None,
                 "params": params,
@@ -431,6 +433,12 @@ class ERC7730InputToResolved(ERC7730Converter[InputERC7730Descriptor, ResolvedER
         constants: ConstantProvider,
         out: OutputAdder,
     ) -> list[ResolvedNestedFields | ResolvedFieldDescription] | None:
+        if fields.path is None:
+            return out.error(
+                title="Unsupported nested fields value",
+                message="Nested fields are only supported with data paths and not constant values.",
+            )
+
         path: DataPath
         match constants.resolve_path(fields.path, out):
             case None:
@@ -461,6 +469,6 @@ class ERC7730InputToResolved(ERC7730Converter[InputERC7730Descriptor, ResolvedER
                     message="Using nested fields on an array slice is not allowed.",
                 )
             case Array():
-                return [ResolvedNestedFields(path=path, fields=resolved_fields)]
+                return [ResolvedNestedFields(value=ResolvedValuePath(path=path), fields=resolved_fields)]
             case _:
                 assert_never(path.elements[-1])

--- a/src/erc7730/convert/resolved/references.py
+++ b/src/erc7730/convert/resolved/references.py
@@ -8,6 +8,7 @@ from erc7730.common.output import OutputAdder
 from erc7730.common.pydantic import model_to_json_str
 from erc7730.convert.resolved.constants import ConstantProvider
 from erc7730.convert.resolved.parameters import resolve_field_parameters
+from erc7730.convert.resolved.values import resolve_value
 from erc7730.model.display import (
     FieldFormat,
 )
@@ -18,7 +19,7 @@ from erc7730.model.input.display import (
 )
 from erc7730.model.metadata import EnumDefinition
 from erc7730.model.paths import DataPath, DescriptorPath, Field
-from erc7730.model.paths.path_ops import data_or_container_path_concat, descriptor_path_strip_prefix
+from erc7730.model.paths.path_ops import descriptor_path_strip_prefix
 from erc7730.model.resolved.display import (
     ResolvedField,
     ResolvedFieldDescription,
@@ -60,11 +61,11 @@ def resolve_reference(
         if (resolved_params := resolve_field_parameters(prefix, input_params, enums, constants, out)) is None:
             return None
 
-    if (path := constants.resolve_path(reference.path, out)) is None:
+    if (value := resolve_value(prefix, reference, constants, out)) is None:
         return None
 
     return ResolvedFieldDescription(
-        path=data_or_container_path_concat(prefix, path),
+        value=value,
         label=str(constants.resolve(label, out)),
         format=FieldFormat(definition.format),
         params=resolved_params,

--- a/src/erc7730/convert/resolved/values.py
+++ b/src/erc7730/convert/resolved/values.py
@@ -1,0 +1,39 @@
+from erc7730.common.output import OutputAdder
+from erc7730.convert.resolved.constants import ConstantProvider
+from erc7730.model.input.display import InputFieldBase
+from erc7730.model.paths import DataPath
+from erc7730.model.paths.path_ops import data_or_container_path_concat
+from erc7730.model.resolved.display import ResolvedValue, ResolvedValueConstant, ResolvedValuePath
+
+
+def resolve_value(
+    prefix: DataPath,
+    input_field: InputFieldBase,
+    constants: ConstantProvider,
+    out: OutputAdder,
+) -> ResolvedValue | None:
+    if (input_path := input_field.path) is not None:
+        if input_field.value is not None:
+            return out.error(
+                title="Invalid field",
+                message="Field cannot have both a path and a value.",
+            )
+
+        if (path := constants.resolve_path(input_path, out)) is None:
+            return None
+
+        return ResolvedValuePath(path=data_or_container_path_concat(prefix, path))
+
+    if (input_value := input_field.value) is not None:
+        if (value := constants.resolve(input_value, out)) is None:
+            return None
+
+        if not isinstance(value, str | bool | int | float):
+            return out.error(
+                title="Invalid constant value",
+                message="Constant value must be a scalar type (string, boolean or number).",
+            )
+
+        return ResolvedValueConstant(value=value)
+
+    return out.error(title="Invalid field", message="Field must have either a path or a value.")

--- a/src/erc7730/model/paths/path_schemas.py
+++ b/src/erc7730/model/paths/path_schemas.py
@@ -28,6 +28,9 @@ from erc7730.model.resolved.display import (
     ResolvedNftNameParameters,
     ResolvedTokenAmountParameters,
     ResolvedUnitParameters,
+    ResolvedValue,
+    ResolvedValueConstant,
+    ResolvedValuePath,
 )
 from erc7730.model.resolved.path import ResolvedPath
 
@@ -137,8 +140,19 @@ def compute_format_schema_paths(format: ResolvedFormat) -> FormatPaths:
                 case _:
                     assert_never(path)
 
+        def add_value(value: ResolvedValue | None) -> None:
+            match value:
+                case None:
+                    pass
+                case ResolvedValueConstant():
+                    pass
+                case ResolvedValuePath(path=path):
+                    add_path(path)
+                case _:
+                    assert_never(value)
+
         def append_paths(field: ResolvedField) -> None:
-            add_path(field.path)
+            add_value(field.value)
             match field:
                 case ResolvedFieldDescription():
                     match field.params:

--- a/src/erc7730/model/resolved/display.py
+++ b/src/erc7730/model/resolved/display.py
@@ -1,4 +1,4 @@
-from typing import Annotated, ForwardRef
+from typing import Annotated, ForwardRef, Literal
 
 from eip712.model.schema import EIP712Type
 from pydantic import Discriminator, Field, Tag
@@ -12,7 +12,7 @@ from erc7730.model.display import (
 )
 from erc7730.model.paths import ContainerPath, DataPath
 from erc7730.model.resolved.path import ResolvedPath
-from erc7730.model.types import Address, HexStr, Id, Selector
+from erc7730.model.types import Address, HexStr, Id, ScalarType, Selector
 from erc7730.model.unions import field_discriminator, field_parameters_discriminator
 
 # ruff: noqa: N815 - camel case field names are tolerated to match schema
@@ -158,15 +158,57 @@ ResolvedFieldParameters = Annotated[
 ]
 
 
-class ResolvedFieldBase(Model):
+class ResolvedValuePath(Model):
     """
-    A field formatter, containing formatting information of a single field in a message.
+    A path to the field in the structured data. The path is a JSON path expression that can be used to extract the
+    field value from the structured data.
     """
+
+    type: Literal["path"] = Field(
+        default="path",
+        title="Value Type",
+        description="The value type identifier (discriminator for values discriminated union).",
+    )
 
     path: ResolvedPath = Field(
         title="Path",
         description="A path to the field in the structured data. The path is a JSON path expression that can be used "
         "to extract the field value from the structured data.",
+    )
+
+
+class ResolvedValueConstant(Model):
+    """
+    A constant value.
+    """
+
+    type: Literal["constant"] = Field(
+        default="constant",
+        title="Value Type",
+        description="The value type identifier (discriminator for values discriminated union).",
+    )
+
+    value: ScalarType = Field(
+        title="Value",
+        description="The constant value.",
+    )
+
+
+ResolvedValue = Annotated[
+    ResolvedValuePath | ResolvedValueConstant,
+    Discriminator("type"),
+]
+
+
+class ResolvedFieldBase(Model):
+    """
+    A field formatter, containing formatting information of a single field in a message.
+    """
+
+    value: ResolvedValue = Field(
+        title="Value",
+        description="A reference to the value to display, either as path to a field in the structured data or a "
+        "constant value.",
     )
 
 

--- a/src/erc7730/model/unions.py
+++ b/src/erc7730/model/unions.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from erc7730.common.properties import has_property
+from erc7730.common.properties import has_any_property
 
 
 def field_discriminator(v: Any) -> str | None:
@@ -10,11 +10,11 @@ def field_discriminator(v: Any) -> str | None:
     :param v: deserialized raw data
     :return: the discriminator tag
     """
-    if has_property(v, "$ref"):
+    if has_any_property(v, "$ref"):
         return "reference"
-    if has_property(v, "fields"):
+    if has_any_property(v, "fields"):
         return "nested_fields"
-    if has_property(v, "label"):
+    if has_any_property(v, "label"):
         return "field_description"
     return None
 
@@ -26,18 +26,18 @@ def field_parameters_discriminator(v: Any) -> str | None:
     :param v: deserialized raw data
     :return: the discriminator tag
     """
-    if has_property(v, "tokenPath") or has_property(v, "nativeCurrencyAddress"):
+    if has_any_property(v, "tokenPath", "token", "nativeCurrencyAddress"):
         return "token_amount"
-    if has_property(v, "encoding"):
+    if has_any_property(v, "encoding"):
         return "date"
-    if has_property(v, "collectionPath"):
+    if has_any_property(v, "collectionPath", "collection"):
         return "nft_name"
-    if has_property(v, "base"):
+    if has_any_property(v, "base"):
         return "unit"
-    if has_property(v, "$ref") or has_property(v, "ref") or has_property(v, "enumId"):
+    if has_any_property(v, "$ref", "ref", "enumId"):
         return "enum"
-    if has_property(v, "calleePath") or has_property(v, "selector"):
+    if has_any_property(v, "calleePath", "callee", "selector"):
         return "call_data"
-    if has_property(v, "sources") or has_property(v, "types"):
+    if has_any_property(v, "sources", "types"):
         return "address_name"
     return None

--- a/tests/convert/resolved/data/definition_format_address_name_resolved.json
+++ b/tests/convert/resolved/data/definition_format_address_name_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "addressName",
             "params": { "types": ["wallet", "eoa", "token", "contract", "collection"], "sources": ["local", "ens"] }

--- a/tests/convert/resolved/data/definition_format_amount_resolved.json
+++ b/tests/convert/resolved/data/definition_format_amount_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "amount"
           }

--- a/tests/convert/resolved/data/definition_format_calldata_resolved.json
+++ b/tests/convert/resolved/data/definition_format_calldata_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] } },
             "label": "Param 2",
             "format": "calldata",
             "params": {

--- a/tests/convert/resolved/data/definition_format_date_resolved.json
+++ b/tests/convert/resolved/data/definition_format_date_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "date",
             "params": { "encoding": "blockheight" }

--- a/tests/convert/resolved/data/definition_format_duration_resolved.json
+++ b/tests/convert/resolved/data/definition_format_duration_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "duration"
           }

--- a/tests/convert/resolved/data/definition_format_enum_resolved.json
+++ b/tests/convert/resolved/data/definition_format_enum_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "enum",
             "params": { "enumId": "testEnum" }

--- a/tests/convert/resolved/data/definition_format_nft_name_resolved.json
+++ b/tests/convert/resolved/data/definition_format_nft_name_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "nftName",
             "params": { "collectionPath": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "collection1" }] } }

--- a/tests/convert/resolved/data/definition_format_raw_resolved.json
+++ b/tests/convert/resolved/data/definition_format_raw_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "raw"
           }

--- a/tests/convert/resolved/data/definition_format_token_amount_resolved.json
+++ b/tests/convert/resolved/data/definition_format_token_amount_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "tokenAmount",
             "params": { "tokenPath": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "token1" }] } }

--- a/tests/convert/resolved/data/definition_format_unit_resolved.json
+++ b/tests/convert/resolved/data/definition_format_unit_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "unit",
             "params": { "base": "km/h", "decimals": 2, "prefix": true }

--- a/tests/convert/resolved/data/definition_override_label_resolved.json
+++ b/tests/convert/resolved/data/definition_override_label_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1 custom",
             "format": "raw"
           }

--- a/tests/convert/resolved/data/definition_override_params_resolved.json
+++ b/tests/convert/resolved/data/definition_override_params_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "tokenAmount",
             "params": { "tokenPath": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "token2" }] } }

--- a/tests/convert/resolved/data/definition_using_constants_resolved.json
+++ b/tests/convert/resolved/data/definition_using_constants_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "tokenAmount",
             "params": {

--- a/tests/convert/resolved/data/format_address_name_resolved.json
+++ b/tests/convert/resolved/data/format_address_name_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "All parameters specified",
             "format": "addressName",
             "params": { "types": ["wallet", "eoa", "token", "contract", "collection"], "sources": ["local", "ens"] }

--- a/tests/convert/resolved/data/format_address_name_using_constants_resolved.json
+++ b/tests/convert/resolved/data/format_address_name_using_constants_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "All parameters specified",
             "format": "addressName",
             "params": { "types": ["wallet", "eoa", "token", "contract", "collection"], "sources": ["local", "ens"] }

--- a/tests/convert/resolved/data/format_amount_resolved.json
+++ b/tests/convert/resolved/data/format_amount_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "amount"
           }

--- a/tests/convert/resolved/data/format_amount_using_constants_resolved.json
+++ b/tests/convert/resolved/data/format_amount_using_constants_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "amount"
           }

--- a/tests/convert/resolved/data/format_calldata_resolved.json
+++ b/tests/convert/resolved/data/format_calldata_resolved.json
@@ -23,13 +23,13 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] } },
             "label": "With minimal set of parameters specified",
             "format": "calldata",
             "params": { "calleePath": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } }
           },
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] } },
             "label": "With all parameters specified",
             "format": "calldata",
             "params": {

--- a/tests/convert/resolved/data/format_calldata_using_constants_resolved.json
+++ b/tests/convert/resolved/data/format_calldata_using_constants_resolved.json
@@ -23,13 +23,13 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] } },
             "label": "With minimal set of parameters specified",
             "format": "calldata",
             "params": { "calleePath": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } }
           },
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] } },
             "label": "With all parameters specified",
             "format": "calldata",
             "params": {

--- a/tests/convert/resolved/data/format_date_resolved.json
+++ b/tests/convert/resolved/data/format_date_resolved.json
@@ -23,13 +23,13 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1 - with blockheight encoding",
             "format": "date",
             "params": { "encoding": "blockheight" }
           },
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1 - with timestamp encoding",
             "format": "date",
             "params": { "encoding": "timestamp" }

--- a/tests/convert/resolved/data/format_date_using_constants_resolved.json
+++ b/tests/convert/resolved/data/format_date_using_constants_resolved.json
@@ -23,13 +23,13 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1 - with blockheight encoding",
             "format": "date",
             "params": { "encoding": "blockheight" }
           },
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1 - with timestamp encoding",
             "format": "date",
             "params": { "encoding": "timestamp" }

--- a/tests/convert/resolved/data/format_duration_resolved.json
+++ b/tests/convert/resolved/data/format_duration_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "duration"
           }

--- a/tests/convert/resolved/data/format_duration_using_constants_resolved.json
+++ b/tests/convert/resolved/data/format_duration_using_constants_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "duration"
           }

--- a/tests/convert/resolved/data/format_enum_resolved.json
+++ b/tests/convert/resolved/data/format_enum_resolved.json
@@ -23,13 +23,13 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Using a local enum",
             "format": "enum",
             "params": { "enumId": "local" }
           },
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Using a remote enum",
             "format": "enum",
             "params": { "enumId": "remote" }

--- a/tests/convert/resolved/data/format_enum_using_constants_resolved.json
+++ b/tests/convert/resolved/data/format_enum_using_constants_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "enum",
             "params": { "enumId": "testEnum" }

--- a/tests/convert/resolved/data/format_nft_name_resolved.json
+++ b/tests/convert/resolved/data/format_nft_name_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "nftName",
             "params": { "collectionPath": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] } }

--- a/tests/convert/resolved/data/format_nft_name_using_constants_resolved.json
+++ b/tests/convert/resolved/data/format_nft_name_using_constants_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "nftName",
             "params": { "collectionPath": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param2" }] } }

--- a/tests/convert/resolved/data/format_raw_resolved.json
+++ b/tests/convert/resolved/data/format_raw_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "raw"
           }

--- a/tests/convert/resolved/data/format_raw_using_constants_resolved.json
+++ b/tests/convert/resolved/data/format_raw_using_constants_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "raw"
           }

--- a/tests/convert/resolved/data/format_token_amount_resolved.json
+++ b/tests/convert/resolved/data/format_token_amount_resolved.json
@@ -23,12 +23,12 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "With minimal set of parameters specified",
             "format": "tokenAmount"
           },
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "With all parameters specified, string nativeCurrencyAddress",
             "format": "tokenAmount",
             "params": {
@@ -39,7 +39,7 @@
             }
           },
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "With all parameters specified, array nativeCurrencyAddress",
             "format": "tokenAmount",
             "params": {

--- a/tests/convert/resolved/data/format_token_amount_using_constants_resolved.json
+++ b/tests/convert/resolved/data/format_token_amount_using_constants_resolved.json
@@ -23,12 +23,12 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "With minimal set of parameters specified",
             "format": "tokenAmount"
           },
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "With all parameters specified, string nativeCurrencyAddress",
             "format": "tokenAmount",
             "params": {
@@ -39,7 +39,7 @@
             }
           },
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "With all parameters specified, array nativeCurrencyAddress",
             "format": "tokenAmount",
             "params": {

--- a/tests/convert/resolved/data/format_unit_resolved.json
+++ b/tests/convert/resolved/data/format_unit_resolved.json
@@ -23,13 +23,13 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "With minimal set of parameters set",
             "format": "unit",
             "params": { "base": "%" }
           },
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "With all parameters set",
             "format": "unit",
             "params": { "base": "km/h", "decimals": 2, "prefix": true }

--- a/tests/convert/resolved/data/format_unit_using_constants_resolved.json
+++ b/tests/convert/resolved/data/format_unit_using_constants_resolved.json
@@ -23,13 +23,13 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "With minimal set of parameters set",
             "format": "unit",
             "params": { "base": "km/h" }
           },
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "With all parameters set",
             "format": "unit",
             "params": { "base": "km/h", "decimals": 2, "prefix": true }

--- a/tests/convert/resolved/data/minimal_contract_resolved.json
+++ b/tests/convert/resolved/data/minimal_contract_resolved.json
@@ -18,7 +18,7 @@
       "0x5ca8f297": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "raw"
           }

--- a/tests/convert/resolved/data/minimal_eip712_resolved.json
+++ b/tests/convert/resolved/data/minimal_eip712_resolved.json
@@ -23,7 +23,7 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] },
+            "value": { "type": "path", "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }] } },
             "label": "Param 1",
             "format": "raw"
           }

--- a/tests/convert/resolved/data/nested_fields_eip712_array_resolved.json
+++ b/tests/convert/resolved/data/nested_fields_eip712_array_resolved.json
@@ -24,22 +24,31 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }, { "type": "array" }] },
+            "value": {
+              "type": "path",
+              "path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "param1" }, { "type": "array" }] }
+            },
             "fields": [
               {
-                "path": {
-                  "type": "data",
-                  "absolute": true,
-                  "elements": [{ "type": "field", "identifier": "param1" }, { "type": "array" }, { "type": "field", "identifier": "subparam1" }]
+                "value": {
+                  "type": "path",
+                  "path": {
+                    "type": "data",
+                    "absolute": true,
+                    "elements": [{ "type": "field", "identifier": "param1" }, { "type": "array" }, { "type": "field", "identifier": "subparam1" }]
+                  }
                 },
                 "label": "Subparam 1",
                 "format": "raw"
               },
               {
-                "path": {
-                  "type": "data",
-                  "absolute": true,
-                  "elements": [{ "type": "field", "identifier": "param1" }, { "type": "array" }, { "type": "field", "identifier": "subparam2" }]
+                "value": {
+                  "type": "path",
+                  "path": {
+                    "type": "data",
+                    "absolute": true,
+                    "elements": [{ "type": "field", "identifier": "param1" }, { "type": "array" }, { "type": "field", "identifier": "subparam2" }]
+                  }
                 },
                 "label": "Subparam 2",
                 "format": "raw"

--- a/tests/convert/resolved/data/nested_fields_eip712_struct_resolved.json
+++ b/tests/convert/resolved/data/nested_fields_eip712_struct_resolved.json
@@ -24,19 +24,25 @@
       "TestPrimaryType": {
         "fields": [
           {
-            "path": {
-              "type": "data",
-              "absolute": true,
-              "elements": [{ "type": "field", "identifier": "param1" }, { "type": "field", "identifier": "subparam1" }]
+            "value": {
+              "type": "path",
+              "path": {
+                "type": "data",
+                "absolute": true,
+                "elements": [{ "type": "field", "identifier": "param1" }, { "type": "field", "identifier": "subparam1" }]
+              }
             },
             "label": "Subparam 1",
             "format": "raw"
           },
           {
-            "path": {
-              "type": "data",
-              "absolute": true,
-              "elements": [{ "type": "field", "identifier": "param1" }, { "type": "field", "identifier": "subparam2" }]
+            "value": {
+              "type": "path",
+              "path": {
+                "type": "data",
+                "absolute": true,
+                "elements": [{ "type": "field", "identifier": "param1" }, { "type": "field", "identifier": "subparam2" }]
+              }
             },
             "label": "Subparam 2",
             "format": "raw"


### PR DESCRIPTION
Update to align with https://github.com/LedgerHQ/clear-signing-erc7730-registry/pull/109

- [x] add support for constant `value` instead of `path` in all fields
- [ ] add support for constant `token` instead of `tokenPath` when using `tokenAmount` format
- [ ] add support for constant `collection` instead of `collectionPath` when using `nftName` format
- [ ] add support for constant `callee` instead of `calleePath` when using `calldata` format

