### PR TITLE
feat(BACK-8208): tooling: Allow generation from string inputs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         name: check yaml files (yamllint)
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -51,7 +51,7 @@ repos:
           - --py310-plus
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: pycln
         name: remove unused imports (pycln)

--- a/src/erc7730/main.py
+++ b/src/erc7730/main.py
@@ -155,11 +155,24 @@ def command_generate(
     legal_name: Annotated[str | None, Option(help="The full legal name of the owner")] = None,
     url: Annotated[str | None, Option(help="URL with more info on the entity interacted with")] = None,
 ) -> None:
+    if schema is not None and abi is not None:
+        print("Cannot specify both ABI and schema.")
+        raise Exit(1)
+    schema_buffer = None
+    abi_buffer = None
+
+    if schema is not None:
+        with open(schema, "rb") as f:
+            schema_buffer = f.read()
+    elif abi is not None:
+        with open(abi, "rb") as f:
+            abi_buffer = f.read()
+
     descriptor = generate_descriptor(
         chain_id=chain_id,
         contract_address=address,
-        abi_file=abi,
-        eip712_schema_file=schema,
+        abi=abi_buffer,
+        eip712_schema=schema_buffer,
         owner=owner,
         legal_name=legal_name,
         url=HttpUrl(url) if url is not None else None,

--- a/tests/generate/test_generate.py
+++ b/tests/generate/test_generate.py
@@ -29,23 +29,49 @@ def test_generate_from_contract_address(label: str, chain_id: int, contract_addr
 
 
 @pytest.mark.parametrize("test_file", sorted(glob(str(DATA / "abis*.json"))), ids=lambda f: Path(f).stem)
-def test_generate_from_abis(test_file: str) -> None:
+def test_generate_from_abis_buffer(test_file: str) -> None:
     """Generate descriptor using a provided ABI file."""
-    _assert_descriptor_valid(
-        generate_descriptor(
-            chain_id=1, contract_address=Address("0x0000000000000000000000000000000000000000"), abi_file=Path(test_file)
+    with open(test_file, "rb") as f:
+        _assert_descriptor_valid(
+            generate_descriptor(
+                chain_id=1, contract_address=Address("0x0000000000000000000000000000000000000000"), abi=f.read()
+            )
         )
+
+
+@pytest.mark.parametrize("test_file", sorted(glob(str(DATA / "abis*.json"))), ids=lambda f: Path(f).stem)
+def test_generate_from_abis_string(test_file: str) -> None:
+    """Generate descriptor using a provided ABI file."""
+    with open(test_file, "rb") as f:
+        abi = f.read().decode("utf-8")
+    _assert_descriptor_valid(
+        generate_descriptor(chain_id=1, contract_address=Address("0x0000000000000000000000000000000000000000"), abi=abi)
     )
 
 
 @pytest.mark.parametrize("test_file", sorted(glob(str(DATA / "schemas*.json"))), ids=lambda f: Path(f).stem)
-def test_generate_from_eip712_schemas(test_file: str) -> None:
+def test_generate_from_eip712_schemas_buffer(test_file: str) -> None:
     """Generate descriptor using a provided EIP-712 file."""
+    with open(test_file, "rb") as f:
+        _assert_descriptor_valid(
+            generate_descriptor(
+                chain_id=1,
+                contract_address=Address("0x0000000000000000000000000000000000000000"),
+                eip712_schema=f.read(),
+            )
+        )
+
+
+@pytest.mark.parametrize("test_file", sorted(glob(str(DATA / "schemas*.json"))), ids=lambda f: Path(f).stem)
+def test_generate_from_eip712_schemas_string(test_file: str) -> None:
+    """Generate descriptor using a provided EIP-712 file."""
+    with open(test_file, "rb") as f:
+        schema = f.read().decode("utf-8")
     _assert_descriptor_valid(
         generate_descriptor(
             chain_id=1,
             contract_address=Address("0x0000000000000000000000000000000000000000"),
-            eip712_schema_file=Path(test_file),
+            eip712_schema=schema,
         )
     )
 


### PR DESCRIPTION
**Breaking change**

`generate.generate_descriptor` interface change: method now expects either string or bytes rather than path. Path should be resolved by caller.

```python
generate_descriptor(chain_id=..., contract_address=..., abi_file="/path/to/abi.json")
```

Should be replaced by:

```python
with open("/path/to/abi.json", "rb") as f:
   generate_descriptor(chain_id=..., contract_address=..., abi=f.read())
```

CLI is unchanged.