### PR TITLE
fix: Allow zero-size fields in display

### DIFF
--- a/src/erc7730/model/input/display.py
+++ b/src/erc7730/model/input/display.py
@@ -327,7 +327,6 @@ class InputFormat(FormatBase):
     fields: list[InputField] = Field(
         title="Field Formats set",
         description="An array containing the ordered definitions of fields formats.",
-        min_length=1,
     )
 
     required: list[DataPathStr | ContainerPathStr] | None = Field(


### PR DESCRIPTION
Context:
https://github.com/LedgerHQ/clear-signing-erc7730-registry/actions/runs/13637196842