### PR TITLE
feat(BACK-8471): Implementation of calldata conversion

### DIFF
--- a/src/erc7730/common/binary.py
+++ b/src/erc7730/common/binary.py
@@ -1,0 +1,55 @@
+"""Utilities for binary data manipulation."""
+
+from enum import IntEnum
+
+
+def from_hex(value: str) -> bytes:
+    """
+    Convert an hex string to a byte array.
+
+    @param value: hex string (can be prefixed with 0x or not)
+    @return: decoded byte array
+    """
+    return bytes.fromhex(value.removeprefix("0x"))
+
+
+def tlv(tag: int | IntEnum, *value: bytes | str | None) -> bytes:
+    """
+    Encode a value in TLV format (Tag-Length-Value)
+
+    If value is not encoded, it will be encoded as ASCII.
+    If input string is not ASCII, and UnicodeEncodeError is raised.
+
+    If encoded value is longer than 255 bytes, an OverflowError is raised.
+
+    @param tag: the tag (can be an enum)
+    @param value: the value (can be already encoded, or a string)
+    @return: encoded TLV
+    """
+    values_encoded = bytearray()
+    for v in value:
+        if v is not None:
+            values_encoded.extend(v.encode("ascii", errors="strict") if isinstance(v, str) else v)
+    return (
+        (tag.value if isinstance(tag, IntEnum) else tag).to_bytes(1, "big")
+        + len(values_encoded).to_bytes(1, "big")
+        + values_encoded
+    )
+
+
+def length_value(value: bytes | str | None) -> bytes:
+    """
+    Prepend the length of the value encoded on 1 byte to the value itself.
+
+    If value is not encoded, it will be encoded as ASCII.
+    If input string is not ASCII, and UnicodeEncodeError is raised.
+
+    If encoded value is longer than 255 bytes, an OverflowError is raised.
+
+    @param value: the value (can be already encoded, or a string)
+    @return: encoded TLV
+    """
+    if value is None:
+        return (0).to_bytes(1, "big")
+    value_encoded = value.encode("ascii", errors="strict") if isinstance(value, str) else value
+    return len(value_encoded).to_bytes(1, "big") + value_encoded

--- a/src/erc7730/convert/calldata/__init__.py
+++ b/src/erc7730/convert/calldata/__init__.py
@@ -1,0 +1,5 @@
+"""
+Conversion to Ledger specific calldata descriptor (also referred to as "generic parser" descriptor).
+
+See documentation in https://github.com/LedgerHQ/app-ethereum for specifications of this protocol
+"""

--- a/src/erc7730/convert/calldata/convert_erc7730_input_to_calldata.py
+++ b/src/erc7730/convert/calldata/convert_erc7730_input_to_calldata.py
@@ -1,0 +1,41 @@
+from pydantic_string_url import HttpUrl
+
+from erc7730.common.output import ConsoleOutputAdder
+from erc7730.convert.calldata.v1.descriptor import (
+    convert_descriptor,
+)
+from erc7730.model.calldata.descriptor import CalldataDescriptor
+from erc7730.model.input.context import InputContractContext
+from erc7730.model.input.descriptor import InputERC7730Descriptor
+from erc7730.model.input.lenses import get_chain_ids
+
+
+def erc7730_descriptor_to_calldata_descriptors(
+    input_descriptor: InputERC7730Descriptor, source: HttpUrl | None = None, chain_id: int | None = None
+) -> list[CalldataDescriptor]:
+    """
+    Generate output calldata descriptors from input ERC-7730 descriptor with contract context.
+
+    If descriptor is invalid, an empty list is returned. If the descriptor is partially invalid, a partial list is
+    returned. Errors are logged as warnings.
+
+    :param input_descriptor: input descriptor
+    :param source: source of the descriptor file
+    :param chain_id: if set, only emit calldata descriptors for given chain IDs
+    :return: output calldata descriptors (1 per chain + selector)
+    """
+
+    out = ConsoleOutputAdder()
+    try:
+        if not isinstance(input_descriptor.context, InputContractContext):
+            return []
+
+        if chain_id is not None and chain_id not in get_chain_ids(input_descriptor):
+            return []
+
+        return convert_descriptor(input_descriptor=input_descriptor, source=source, chain_id=chain_id, out=out)
+
+    except Exception:
+        out.warning(f"Error processing ERC-7730 file {source}, skipping it")
+
+    return []

--- a/src/erc7730/convert/calldata/v1/__init__.py
+++ b/src/erc7730/convert/calldata/v1/__init__.py
@@ -1,0 +1,9 @@
+"""
+Version 1 of the conversion to Ledger specific calldata descriptor (also referred to as "generic parser" descriptor).
+
+See documentation in https://github.com/LedgerHQ/app-ethereum for specifications of this protocol
+
+The version 1 of the protocol comes with the following limitations:
+ - Nested array fields are only partially supported
+ - Recursive invocations using fields with "calldata" format are not supported
+"""

--- a/src/erc7730/convert/calldata/v1/abi.py
+++ b/src/erc7730/convert/calldata/v1/abi.py
@@ -1,0 +1,238 @@
+"""
+Conversion of a function ABI to an ABI tree.
+
+An ABI tree is a tree representation of the ABI of a function inputs, enriched with some metadata to ease crafting
+paths to access values in the serialized calldata.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Annotated, Literal, assert_never, override
+
+import eth_abi
+from eth_abi.grammar import BasicType, TupleType
+from pydantic import Field
+
+from erc7730.model.abi import Component, Function, InputOutput
+from erc7730.model.base import Model
+from erc7730.model.calldata.v1.value import (
+    CalldataDescriptorTypeFamily,
+)
+
+
+class ABINode(Model, ABC):
+    """Represents a node in the tree defined by a function ABI."""
+
+    @property
+    @abstractmethod
+    def is_dynamic(self) -> bool:
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def size(self) -> int:
+        raise NotImplementedError()
+
+
+class ABILeafNode(ABINode, ABC):
+    """Represents a leaf node in the tree defined by a function ABI."""
+
+    type_family: CalldataDescriptorTypeFamily = Field(title="Data type family")
+    type_size: int | None = Field(default=None, title="Data type size (in bytes)")
+
+
+class ABIStruct(ABINode):
+    """ABI node representing a function or a tuple."""
+
+    type: Literal["struct"] = Field(default="struct", title="ABI tree node type")
+    components: dict[str, "ABITree"] = Field(title="Struct components")
+    offsets: dict[str, int] = Field(title="Struct components offsets")
+
+    @override
+    @property
+    def is_dynamic(self) -> bool:
+        return any(comp.is_dynamic for comp in self.components.values())
+
+    @override
+    @property
+    def size(self) -> int:
+        return 1 if self.is_dynamic else sum(comp.size for comp in self.components.values())
+
+
+class ABIStaticArray(ABINode):
+    """ABI node representing an array with static size."""
+
+    type: Literal["static_array"] = Field(default="static_array", title="ABI tree node type")
+    dimension: int = Field(title="Array dimension", ge=0)
+    component: "ABITree" = Field(title="Array element type")
+
+    @override
+    @property
+    def is_dynamic(self) -> bool:
+        return self.component.is_dynamic
+
+    @override
+    @property
+    def size(self) -> int:
+        return 1 if self.is_dynamic else self.dimension * self.component.size
+
+
+class ABIDynamicArray(ABINode):
+    """ABI node representing an array with dynamic size."""
+
+    type: Literal["dynamic_array"] = Field(default="dynamic_array", title="ABI tree node type")
+    component: "ABITree" = Field(title="Array element type")
+
+    @override
+    @property
+    def is_dynamic(self) -> bool:
+        return True
+
+    @override
+    @property
+    def size(self) -> int:
+        return 1
+
+
+class ABIStaticLeaf(ABILeafNode):
+    """ABI node representing a scalar type with static size."""
+
+    type: Literal["static_leaf"] = Field(default="static_leaf", title="ABI tree node type")
+
+    @override
+    @property
+    def is_dynamic(self) -> bool:
+        return False
+
+    @override
+    @property
+    def size(self) -> int:
+        return 1
+
+
+class ABIDynamicLeaf(ABILeafNode):
+    """ABI node representing a scalar type with dynamic size."""
+
+    type: Literal["dynamic_leaf"] = Field(default="dynamic_leaf", title="ABI tree node type")
+
+    @override
+    @property
+    def is_dynamic(self) -> bool:
+        return True
+
+    @override
+    @property
+    def size(self) -> int:
+        return 1
+
+
+ABITree = Annotated[
+    ABIStruct | ABIStaticArray | ABIDynamicArray | ABIStaticLeaf | ABIDynamicLeaf, Field(discriminator="type")
+]
+
+
+def function_to_abi_tree(function: Function) -> ABITree:
+    """
+    Convert a function ABI to an ABI tree.
+
+    An ABI tree is a tree representation of the ABI of a function inputs, enriched with some metadata to ease crafting
+    paths to access values in the serialized calldata.
+
+    @param function: function ABI
+    @return:
+    """
+    return _struct_component_to_abi_tree(function)
+
+
+def _component_to_abi_tree(inp: InputOutput | Component) -> ABITree:
+    """
+    Convert an ABI component to an ABI tree node.
+
+    @param inp: ABI element (can be a single component, or a function input)
+    @return: ABI tree
+    """
+    match eth_abi.grammar.parse(inp.type):
+        case TupleType():
+            return _struct_component_to_abi_tree(inp)
+
+        case BasicType() as tp:
+            if tp.is_array:
+                match tp.base:
+                    case "tuple" | "struct":
+                        component = _struct_component_to_abi_tree(inp)
+                    case _:
+                        component = _component_to_abi_tree(inp.model_copy(update={"type": tp.item_type.to_type_str()}))
+
+                if len(dimension := tp.arrlist[-1]) == 0:
+                    return ABIDynamicArray(component=component)
+                else:
+                    return ABIStaticArray(component=component, dimension=dimension[0])
+
+            match tp.base:
+                case "tuple" | "struct":
+                    return _struct_component_to_abi_tree(inp)
+                case "int":
+                    type_family = CalldataDescriptorTypeFamily.INT
+                    type_size = (tp.sub or 256) // 8
+                case "uint":
+                    type_family = CalldataDescriptorTypeFamily.UINT
+                    type_size = (tp.sub or 256) // 8
+                case "address":
+                    type_family = CalldataDescriptorTypeFamily.ADDRESS
+                    type_size = (tp.sub or 160) // 8
+                case "bool":
+                    type_family = CalldataDescriptorTypeFamily.BOOL
+                    type_size = (tp.sub or 8) // 8
+                case "bytes":
+                    type_family = CalldataDescriptorTypeFamily.BYTES
+                    type_size = tp.sub // 8 if tp.sub else None
+                case "string":
+                    type_family = CalldataDescriptorTypeFamily.STRING
+                    type_size = tp.sub // 8 if tp.sub else None
+                case "fixed" | "ufixed":
+                    raise NotImplementedError("Fixed precision numbers are not supported by v1 of calldata descriptor")
+                case unknown:
+                    raise Exception(f"Unexpected ABI type: {unknown}")
+
+            if tp.is_dynamic:
+                return ABIDynamicLeaf(type_family=type_family, type_size=type_size)
+            else:
+                return ABIStaticLeaf(type_family=type_family, type_size=type_size)
+
+        case unknown:
+            raise Exception(f"Unexpected ABI type: {type(unknown)}")
+
+
+def _struct_component_to_abi_tree(inp: Function | InputOutput | Component) -> ABITree:
+    """
+    Convert a struct-like ABI component to an ABI tree node (can be the top level function directly).
+
+    @param inp: ABI element
+    @return: ABI tree
+    """
+
+    # get inputs/components list based on argument type
+    input_components: list[InputOutput | Component] = []
+    match inp:
+        case Function(inputs=inputs):
+            if inputs is not None:
+                input_components.extend(inputs)
+        case InputOutput(components=inp_components):
+            if inp_components is not None:
+                input_components.extend(inp_components)
+        case Component(components=inp_components):
+            if inp_components is not None:
+                input_components.extend(inp_components)
+        case _:
+            assert_never(inp)
+
+    # recurse and compute field offsets
+    components: dict[str, ABITree] = {}
+    offsets: dict[str, int] = {}
+    offset = 0
+    for _, component in enumerate(input_components):
+        node = _component_to_abi_tree(component)
+        components[component.name] = node
+        offsets[component.name] = offset
+        offset += node.size
+
+    return ABIStruct(components=components, offsets=offsets)

--- a/src/erc7730/convert/calldata/v1/descriptor.py
+++ b/src/erc7730/convert/calldata/v1/descriptor.py
@@ -1,0 +1,79 @@
+"""
+Conversion of a root ERC-7730 descriptor to calldata descriptors (1 per chain + selector).
+"""
+
+from typing import cast
+
+from pydantic_string_url import HttpUrl
+
+from erc7730.common.abi import get_functions
+from erc7730.common.ledger import ledger_network_id
+from erc7730.common.output import OutputAdder
+from erc7730.convert.calldata.v1.selector import convert_selector
+from erc7730.convert.resolved.convert_erc7730_input_to_resolved import (
+    ERC7730InputToResolved,
+)
+from erc7730.model.abi import Function
+from erc7730.model.calldata.descriptor import CalldataDescriptor
+from erc7730.model.input.descriptor import InputERC7730Descriptor
+from erc7730.model.resolved.context import ResolvedContractContext
+from erc7730.model.types import Selector
+
+
+def convert_descriptor(
+    input_descriptor: InputERC7730Descriptor,
+    source: HttpUrl | None,
+    chain_id: int | None,
+    out: OutputAdder,
+) -> list[CalldataDescriptor]:
+    """
+    Generate output calldata descriptors from an input ERC-7730 descriptor with contract context.
+
+    If descriptor is invalid, an empty list is returned. If the descriptor is partially invalid, a partial list is
+    returned. Errors are logged as warnings.
+
+    :param input_descriptor: deserialized input ERC-7730 descriptor
+    :param source: source of the descriptor file
+    :param chain_id: if set, only emit calldata descriptors for given chain IDs
+    :param out: error handler
+    :return: output calldata descriptors (1 per chain + selector)
+    """
+
+    if (resolved_descriptor := ERC7730InputToResolved().convert(input_descriptor, out)) is None:
+        return []
+
+    context = cast(ResolvedContractContext, resolved_descriptor.context)
+    abis: dict[Selector, Function] = get_functions(context.contract.abi).functions
+
+    output_descriptors = []
+
+    for deployment in context.contract.deployments:
+        if chain_id is not None and chain_id != deployment.chainId:
+            continue
+
+        if ledger_network_id(deployment.chainId) is None:
+            out.warning(f"Chain id {deployment.chainId} is not known, skipping it")
+            continue
+
+        for selector, format in resolved_descriptor.display.formats.items():
+            if (abi := abis.get(selector)) is None:
+                out.error(
+                    title="Invalid selector",
+                    message=f"Selector {selector} not found in ABI.",
+                )
+                continue
+
+            descriptor = convert_selector(
+                descriptor=resolved_descriptor,
+                deployment=deployment,
+                selector=selector,
+                format=format,
+                abi=abi,
+                source=source,
+                out=out,
+            )
+
+            if descriptor is not None:
+                output_descriptors.append(descriptor)
+
+    return output_descriptors

--- a/src/erc7730/convert/calldata/v1/enum.py
+++ b/src/erc7730/convert/calldata/v1/enum.py
@@ -1,0 +1,39 @@
+"""
+Conversion of ERC-7730 enum definitions to calldata descriptor instructions.
+"""
+
+from eth_typing import ChainId as EthChainId
+
+from erc7730.model.calldata.v1.instruction import (
+    CalldataDescriptorInstructionEnumValueV1,
+)
+from erc7730.model.metadata import EnumDefinition
+from erc7730.model.resolved.context import ResolvedDeployment
+from erc7730.model.types import Id, Selector
+
+
+def convert_enums(
+    deployment: ResolvedDeployment, selector: Selector, enums: dict[Id, EnumDefinition] | None
+) -> list[CalldataDescriptorInstructionEnumValueV1]:
+    """
+    Convert descriptor enum definitions to calldata descriptor enum value instructions.
+
+    @param enums: descriptor enum definitions
+    @return: instructions for each enum entry
+    """
+    if enums is None:
+        return []
+
+    return [
+        CalldataDescriptorInstructionEnumValueV1(
+            chain_id=EthChainId(deployment.chainId),
+            address=deployment.address,
+            selector=selector,
+            id=i,
+            enum_id=enum_id,
+            value=int(ordinal),
+            name=name,
+        )
+        for i, (enum_id, enum) in enumerate(enums.items())
+        for ordinal, name in enum.items()
+    ]

--- a/src/erc7730/convert/calldata/v1/field.py
+++ b/src/erc7730/convert/calldata/v1/field.py
@@ -1,0 +1,216 @@
+"""
+Conversion of ERC-7730 field definitions to calldata descriptor instructions.
+"""
+
+from typing import assert_never, cast
+
+from erc7730.common.output import OutputAdder
+from erc7730.convert.calldata.v1.abi import ABITree
+from erc7730.convert.calldata.v1.path import convert_value
+from erc7730.model.calldata.types import TrustedNameSource, TrustedNameType
+from erc7730.model.calldata.v1.instruction import (
+    CalldataDescriptorInstructionFieldV1,
+)
+from erc7730.model.calldata.v1.param import (
+    CalldataDescriptorDateType,
+    CalldataDescriptorParamAmountV1,
+    CalldataDescriptorParamDatetimeV1,
+    CalldataDescriptorParamDurationV1,
+    CalldataDescriptorParamEnumV1,
+    CalldataDescriptorParamNFTV1,
+    CalldataDescriptorParamRawV1,
+    CalldataDescriptorParamTokenAmountV1,
+    CalldataDescriptorParamTrustedNameV1,
+    CalldataDescriptorParamUnitV1,
+    CalldataDescriptorParamV1,
+)
+from erc7730.model.calldata.v1.value import (
+    CalldataDescriptorValueV1,
+)
+from erc7730.model.display import DateEncoding, FieldFormat
+from erc7730.model.resolved.display import (
+    ResolvedAddressNameParameters,
+    ResolvedDateParameters,
+    ResolvedEnumParameters,
+    ResolvedField,
+    ResolvedFieldDescription,
+    ResolvedNestedFields,
+    ResolvedNftNameParameters,
+    ResolvedTokenAmountParameters,
+    ResolvedUnitParameters,
+)
+from erc7730.model.types import Address, HexStr
+
+
+def convert_field(
+    abi: ABITree,
+    field: ResolvedField,
+    enums: dict[str, int],
+    out: OutputAdder,
+) -> list[CalldataDescriptorInstructionFieldV1] | None:
+    """
+    Convert descriptor field definitions to calldata descriptor field instructions.
+
+    Note that 1 input field can result in multiple output instructions, e.g. for nested fields.
+
+    @param abi: function ABI
+    @param field: resolved field
+    @param enums: mapping of source descriptor enum ids to calldata descriptor enum ids
+    @param out: error handler
+    @return: 1 or more calldata field instructions
+    """
+    match field:
+        case ResolvedFieldDescription():
+            if (param := convert_param(abi=abi, field=field, enums=enums, out=out)) is None:
+                return None
+            return [CalldataDescriptorInstructionFieldV1(name=field.label, param=param)]
+        case ResolvedNestedFields():
+            # note: in v1 of protocol, nested fields are flattened. For instance, if a descriptor defines an array of
+            # tokens with each a name field and an amount field, this will display all the tokens names and then all
+            # the token amounts.
+            instructions = []
+            for nested_field in field.fields:
+                if (nested_instructions := convert_field(abi=abi, field=nested_field, enums=enums, out=out)) is None:
+                    return None
+                instructions.extend(nested_instructions)
+            return instructions
+        case _:
+            assert_never(field)
+
+
+def convert_param(
+    abi: ABITree,
+    field: ResolvedFieldDescription,
+    enums: dict[str, int],
+    out: OutputAdder,
+) -> CalldataDescriptorParamV1 | None:
+    """
+    Convert descriptor field parameters to calldata descriptor field parameters.
+
+    @param abi: function ABI
+    @param field: resolved field description
+    @param enums: mapping of source descriptor enum ids to calldata descriptor enum ids
+    @param out: error handler
+    @return: calldata protocol field parameter
+    """
+    if (value := convert_value(value=field.value, abi=abi, out=out)) is None:
+        return None
+
+    match field.format:
+        case None | FieldFormat.RAW:
+            return CalldataDescriptorParamRawV1(value=value)
+
+        case FieldFormat.ADDRESS_NAME:
+            address_params = cast(ResolvedAddressNameParameters | None, field.params)
+
+            types: list[TrustedNameType] = []
+            sources: list[TrustedNameSource] = []
+
+            if address_params is not None:
+                if (input_types := address_params.types) is not None:
+                    types = [TrustedNameType(type) for type in input_types]
+
+                # since sources are free form in ERC-7730, we apply the following algorithm:
+                #   1) assign valid sources based on type
+                #   2) add sources that perfectly match by name
+                for type in types:
+                    match type:
+                        case TrustedNameType.EOA | TrustedNameType.WALLET | TrustedNameType.COLLECTION:
+                            sources.append(TrustedNameSource.ENS)
+                            sources.append(TrustedNameSource.UNSTOPPABLE_DOMAIN)
+                            sources.append(TrustedNameSource.FREENAME)
+                        case TrustedNameType.SMART_CONTRACT | TrustedNameType.TOKEN:
+                            sources.append(TrustedNameSource.CRYPTO_ASSET_LIST)
+                        case TrustedNameType.CONTEXT_ADDRESS:
+                            sources.append(TrustedNameSource.DYNAMIC_RESOLVER)
+                        case _:
+                            assert_never(type)
+
+                if (input_sources := address_params.sources) is not None:
+                    for input_source in input_sources:
+                        if input_source.lower() == "local":
+                            sources.append(TrustedNameSource.LOCAL_ADDRESS_BOOK)
+                        if input_source.lower() in set(TrustedNameSource):
+                            sources.append(TrustedNameSource(input_source.lower()))
+
+            # default to all types / sources allowed, else deduplicate
+            types = list(TrustedNameType) if not types else list(dict.fromkeys(types))
+            sources = list(TrustedNameSource) if not sources else list(dict.fromkeys(sources))
+
+            return CalldataDescriptorParamTrustedNameV1(value=value, types=types, sources=sources)
+
+        case FieldFormat.ENUM:
+            enum_params = cast(ResolvedEnumParameters, field.params)
+
+            if (enum_id := enums.get(enum_params.enumId)) is None:
+                return out.error(
+                    title="Invalid enum id",
+                    message=f"""Failed finding descriptor id for enum {enum_params.enumId}, please report this bug""",
+                )
+
+            return CalldataDescriptorParamEnumV1(value=value, id=enum_id)
+
+        case FieldFormat.UNIT:
+            unit_params = cast(ResolvedUnitParameters, field.params)
+
+            return CalldataDescriptorParamUnitV1(
+                value=value, base=unit_params.base, decimals=unit_params.decimals, prefix=unit_params.prefix
+            )
+
+        case FieldFormat.DURATION:
+            return CalldataDescriptorParamDurationV1(value=value)
+
+        case FieldFormat.NFT_NAME:
+            nft_params = cast(ResolvedNftNameParameters, field.params)
+
+            if (collection_path := convert_value(value=nft_params.collection, abi=abi, out=out)) is None:
+                return None
+
+            return CalldataDescriptorParamNFTV1(value=value, collection=collection_path)
+
+        case FieldFormat.CALL_DATA:
+            # not supported in v1
+            return CalldataDescriptorParamRawV1(value=value)
+
+        case FieldFormat.DATE:
+            date_params = cast(ResolvedDateParameters, field.params)
+
+            match date_params.encoding:
+                case DateEncoding.TIMESTAMP:
+                    date_type = CalldataDescriptorDateType.UNIX
+                case DateEncoding.BLOCKHEIGHT:
+                    date_type = CalldataDescriptorDateType.BLOCK_HEIGHT
+                case _:
+                    assert_never(date_params.encoding)
+
+            return CalldataDescriptorParamDatetimeV1(value=value, date_type=date_type)
+
+        case FieldFormat.AMOUNT:
+            return CalldataDescriptorParamAmountV1(value=value)
+
+        case FieldFormat.TOKEN_AMOUNT:
+            token_path: CalldataDescriptorValueV1 | None = None
+            native_currencies: list[Address] | None = None
+            threshold: HexStr | None = None
+            above_threshold_message: str | None = None
+
+            if (token_amount_params := cast(ResolvedTokenAmountParameters, field.params)) is not None:
+                if token_amount_params.token is None:
+                    token_path = None
+                elif (token_path := convert_value(value=token_amount_params.token, abi=abi, out=out)) is None:
+                    return None
+
+                threshold = token_amount_params.threshold
+                native_currencies = token_amount_params.nativeCurrencyAddress
+                above_threshold_message = token_amount_params.message
+
+            return CalldataDescriptorParamTokenAmountV1(
+                value=value,
+                token=token_path,
+                native_currencies=native_currencies,
+                threshold=threshold,
+                above_threshold_message=above_threshold_message,
+            )
+
+        case _:
+            assert_never(field.format)

--- a/src/erc7730/convert/calldata/v1/path.py
+++ b/src/erc7730/convert/calldata/v1/path.py
@@ -1,0 +1,468 @@
+"""
+Conversion of ERC-7730 ABI paths to calldata descriptor binary paths.
+"""
+
+from typing import Any, assert_never
+
+from erc7730.common.binary import from_hex
+from erc7730.common.output import OutputAdder
+from erc7730.convert.calldata.v1.abi import (
+    ABIDynamicArray,
+    ABIDynamicLeaf,
+    ABIStaticArray,
+    ABIStaticLeaf,
+    ABIStruct,
+    ABITree,
+)
+from erc7730.model.calldata.v1.value import (
+    CalldataDescriptorContainerPathV1,
+    CalldataDescriptorContainerPathValueV1,
+    CalldataDescriptorDataPathV1,
+    CalldataDescriptorPathElementArrayV1,
+    CalldataDescriptorPathElementLeafV1,
+    CalldataDescriptorPathElementRefV1,
+    CalldataDescriptorPathElementSliceV1,
+    CalldataDescriptorPathElementTupleV1,
+    CalldataDescriptorPathElementV1,
+    CalldataDescriptorPathLeafType,
+    CalldataDescriptorTypeFamily,
+    CalldataDescriptorValueConstantV1,
+    CalldataDescriptorValuePathV1,
+    CalldataDescriptorValueV1,
+)
+from erc7730.model.input.path import DataPathStr
+from erc7730.model.paths import (
+    Array,
+    ArrayElement,
+    ArraySlice,
+    ContainerField,
+    DataPath,
+    DataPathElement,
+    Field,
+)
+from erc7730.model.resolved.display import (
+    ResolvedValue,
+    ResolvedValueConstant,
+    ResolvedValuePath,
+)
+from erc7730.model.resolved.path import ContainerPath
+from erc7730.model.types import HexStr
+
+
+def convert_value(
+    value: ResolvedValue,
+    abi: ABITree,
+    out: OutputAdder,
+) -> CalldataDescriptorValueV1 | None:
+    """
+    Convert a value to a calldata protocol value.
+
+    @param value: input container path
+    @param abi: function ABI
+    @param out: error handler
+    @return: output value
+    """
+    match value:
+        case ResolvedValuePath() as path:
+            return convert_path(path, abi, out)
+        case ResolvedValueConstant() as constant:
+            return convert_constant(constant, out)
+        case _:
+            assert_never(value)
+
+
+def convert_constant(
+    constant: ResolvedValueConstant,
+    out: OutputAdder,
+) -> CalldataDescriptorValueConstantV1 | None:
+    """
+    Convert a constant to a calldata protocol value.
+
+    @param constant: input constant value
+    @param out: error handler
+    @return: output value
+    """
+    return CalldataDescriptorValueConstantV1(
+        type_family=CalldataDescriptorTypeFamily[constant.type_family.name],
+        type_size=constant.type_size,
+        value=constant.value,
+        raw=constant.raw,
+    )
+
+
+def convert_path(
+    path: ResolvedValuePath,
+    abi: ABITree,
+    out: OutputAdder,
+) -> CalldataDescriptorValuePathV1 | None:
+    """
+    Convert a path to a calldata protocol value.
+
+    @param path: input path value
+    @param abi: function ABI
+    @param out: error handler
+    @return: output value
+    """
+    match path.path:
+        case ContainerPath() as container_path:
+            return convert_container_path(container_path, out)
+        case DataPath() as data_path:
+            return convert_data_path(data_path, abi, out)
+        case _:
+            assert_never(path.path)
+
+
+def convert_container_path(
+    path: ContainerPath,
+    out: OutputAdder,
+) -> CalldataDescriptorValuePathV1 | None:
+    """
+    Convert a container path to a calldata protocol value.
+
+    @param path: input container path
+    @param out: error handler
+    @return: output binary data path
+    """
+    match path.field:
+        case ContainerField.FROM:
+            field = CalldataDescriptorContainerPathValueV1.FROM
+            type_family = CalldataDescriptorTypeFamily.ADDRESS
+            type_size = 20
+        case ContainerField.TO:
+            field = CalldataDescriptorContainerPathValueV1.TO
+            type_family = CalldataDescriptorTypeFamily.ADDRESS
+            type_size = 20
+        case ContainerField.VALUE:
+            field = CalldataDescriptorContainerPathValueV1.VALUE
+            type_family = CalldataDescriptorTypeFamily.UINT
+            type_size = 32
+        case _:
+            assert_never(path.field)
+    return CalldataDescriptorValuePathV1(
+        abi_path=path,
+        binary_path=CalldataDescriptorContainerPathV1(value=field),
+        type_family=type_family,
+        type_size=type_size,
+    )
+
+
+def convert_data_path(
+    path: DataPath,
+    abi: ABITree,
+    out: OutputAdder,
+) -> CalldataDescriptorValuePathV1 | None:
+    """
+    Convert a data path (representing the path to reach a value in the function ABI) to a Ledger specific binary path,
+    representing cursor movements to reach the same value in a serialized transaction calldata payload.
+
+    @param path: input data path (ABI path)
+    @param abi: function ABI
+    @param out: error handler
+    @return: output binary data path
+    """
+    if len(path.elements) == 0:
+        return out.error(
+            title="Invalid data path",
+            message="Path must refer to a single value in ABI function but an empty path was provided",
+        )
+
+    # current partial path in the ABI + error callback, to raise contextualized errors
+    current_path_in: list[DataPathElement] = []
+
+    def error(message: str) -> CalldataDescriptorValuePathV1 | None:
+        return out.error(
+            title="Invalid data path",
+            message=f"""Path {path} cannot be applied to ABI function "{abi.model_dump_json(indent=2)}: at """
+            f"{DataPathStr(absolute=True, elements=current_path_in)}, {message}",
+        )
+
+    # output path elements
+    path_out: list[CalldataDescriptorPathElementV1] = []
+
+    # current ABI element - note we enrich the ABI for easier processing
+    current_abi_element = abi
+
+    # static paths special case: instead of emitting tuple/array elements, we will accumulate the offset and emit a
+    # single tuple element
+    is_static: bool = not current_abi_element.is_dynamic
+    static_offset: int = 0
+
+    # leaf slice special case: pop it from the path, and we will handle it at the end after the whole path (slice is
+    # only allowed as last element)
+    leaf_slice: ArraySlice | None
+    path_in: list[DataPathElement]
+    match path.elements[-1]:
+        case Array() | Field() | ArrayElement():
+            path_in = path.elements
+            leaf_slice = None
+        case ArraySlice() as s:
+            path_in = path.elements[:-1]
+            leaf_slice = s
+        case _:
+            assert_never(path.elements[-1])
+
+    # iterate data path elements, moving in the ABI tree / emitting binary path elements as needed
+    for current_path_element in path_in:
+        current_path_in.append(current_path_element)
+
+        match (current_path_element, current_abi_element):
+            # field element on a struct => emit a tuple element
+            case (Field(identifier=identifier), ABIStruct(components=abi_components, offsets=abi_offsets)):
+                if (component := abi_components.get(identifier)) is None:
+                    return error(f"""ABI element has no "{identifier}" field""")
+                if (field_offset := abi_offsets.get(identifier)) is None:
+                    return error(f"""ABI element has no offset for "{identifier}" field""")
+
+                if is_static:
+                    static_offset += field_offset
+                else:
+                    path_out.append(CalldataDescriptorPathElementTupleV1(offset=field_offset))
+
+                current_abi_element = component
+
+            # field element on anything else => invalid
+            case (Field(identifier=identifier), _):
+                return error(
+                    f"""cannot reference a struct field ("{identifier}") on a "{current_abi_element.type}" """
+                    "ABI element"
+                )
+
+            # array element on a static array => emit a tuple element
+            case (ArrayElement(index=index), ABIStaticArray(dimension=dimension, component=component)):
+                if index >= dimension or index < -dimension:
+                    return error(f"""index {index}" is out of bounds for array of dimension {dimension}""")
+
+                array_offset = (index if index >= 0 else dimension + index) * component.size
+
+                if is_static:
+                    static_offset += array_offset
+                else:
+                    path_out.append(CalldataDescriptorPathElementTupleV1(offset=array_offset))
+
+                current_abi_element = component
+
+            # array element on a dynamic array => emit an array element
+            case (ArrayElement(index=index), ABIDynamicArray(component=component)):
+                if is_static:
+                    return error("""illegal state: a static path cannot be used on a dynamic array""")
+
+                path_out.append(
+                    CalldataDescriptorPathElementArrayV1(
+                        start=index,
+                        end=None if index == -1 else index + 1,  # edge case for last element
+                        weight=component.size,
+                    )
+                )
+
+                current_abi_element = component
+
+            # array element on anything else => invalid
+            case (ArrayElement(), _):
+                return error(f"""cannot reference an array element on a "{current_abi_element.type}" ABI element""")
+
+            # full array on a static array => emit an array element with no offset
+            case (Array(), ABIStaticArray()):
+                # FIXME We should emit one path per static array element, using
+                #  CalldataDescriptorPathElementTupleV1
+                return error("""full static array is not supported yet""")
+
+            # full array on a dynamic array => emit an array element with no offset
+            case (Array(), ABIDynamicArray(component=component)):
+                path_out.append(CalldataDescriptorPathElementArrayV1(start=None, end=None, weight=component.size))
+
+                current_abi_element = component
+
+            # full array on anything else => invalid
+            case (Array(), _):
+                return error(f"""cannot reference an array on a "{current_abi_element.type}" ABI element""")
+
+            # array slice as inner element => not allowed
+            case (ArraySlice(), _):
+                return error("array slice can only be used as last element of the path")
+
+            case (path_element, abi_element):
+                return error(
+                    f"path does not match ABI structure (path element: {path_element}, ABI element: {abi_element})"
+                )
+
+        # if current element is dynamic, we need to dereference it
+        if current_abi_element.is_dynamic:
+            path_out.append(CalldataDescriptorPathElementRefV1())
+
+    # emit a last static offset to a static value
+    if is_static:
+        path_out.append(CalldataDescriptorPathElementTupleV1(offset=static_offset))
+
+    # append leaf element
+    type_family: CalldataDescriptorTypeFamily
+    type_size: int | None
+    match current_abi_element:
+        case ABIStaticArray() | ABIDynamicArray():
+            raise NotImplementedError("Array leaf is not supported in v1 of protocol")
+        case ABIStruct():
+            raise NotImplementedError("Tuple leaf is not supported in v1 of protocol")
+        case ABIDynamicLeaf():
+            leaf_type = CalldataDescriptorPathLeafType.DYNAMIC_LEAF
+            type_family = current_abi_element.type_family
+            type_size = current_abi_element.type_size
+        case ABIStaticLeaf():
+            leaf_type = CalldataDescriptorPathLeafType.STATIC_LEAF
+            type_family = current_abi_element.type_family
+            type_size = current_abi_element.type_size
+        case _:
+            assert_never(current_abi_element)
+    path_out.append(CalldataDescriptorPathElementLeafV1(leaf_type=leaf_type))
+
+    # if slice is present, emit a slice element
+    if leaf_slice is not None:
+        path_out.append(CalldataDescriptorPathElementSliceV1(start=leaf_slice.start, end=leaf_slice.end))
+
+    return CalldataDescriptorValuePathV1(
+        abi_path=path,
+        binary_path=CalldataDescriptorDataPathV1(elements=path_out),
+        type_family=type_family,
+        type_size=type_size,
+    )
+
+
+def apply_path(calldata: HexStr, path: CalldataDescriptorValuePathV1) -> Any:
+    """
+    Evaluate a path against encoded calldata, to get a decoded value.
+
+    @param calldata: serialized function call data
+    @param path: binary path
+    @return: decoded value
+    """
+    match path.binary_path:
+        case CalldataDescriptorContainerPathV1():
+            raise ValueError("This function only supports data paths")
+        case CalldataDescriptorDataPathV1():
+            raw_value = apply_path_raw(calldata, path.binary_path)
+        case _:
+            assert_never(path.binary_path)
+
+    match path.type_family:
+        case CalldataDescriptorTypeFamily.INT:
+            return int.from_bytes(raw_value, signed=True)
+        case CalldataDescriptorTypeFamily.UINT:
+            return int.from_bytes(raw_value, signed=False)
+        case CalldataDescriptorTypeFamily.FIXED:
+            raise NotImplementedError("Fixed point numbers are not supported")
+        case CalldataDescriptorTypeFamily.UFIXED:
+            raise NotImplementedError("Unsigned fixed point numbers are not supported")
+        case CalldataDescriptorTypeFamily.ADDRESS:
+            return "0x" + raw_value.hex()
+        case CalldataDescriptorTypeFamily.BOOL:
+            return bool(int.from_bytes(raw_value))
+        case CalldataDescriptorTypeFamily.BYTES:
+            return "0x" + raw_value.hex()
+        case CalldataDescriptorTypeFamily.STRING:
+            return raw_value.decode("ascii")
+        case _:
+            assert_never(path.type_family)
+
+
+def apply_path_raw(calldata: HexStr, path: CalldataDescriptorDataPathV1) -> bytes:
+    """
+    Evaluate a path against encoded calldata, to get a raw value.
+
+    @param calldata: serialized function call data
+    @param path: binary path
+    @return: raw value byte array
+    """
+    # decode calldata, strip selector part
+    argdata = from_hex(calldata)[4:]
+
+    # leaf slice special case: pop it from the path, and we will handle it at the end after the whole path (slice is
+    # only allowed as last element)
+    leaf_slice: CalldataDescriptorPathElementSliceV1 | None
+    path_in: list[CalldataDescriptorPathElementV1]
+    match path.elements[-1]:
+        case (
+            CalldataDescriptorPathElementTupleV1()
+            | CalldataDescriptorPathElementArrayV1()
+            | CalldataDescriptorPathElementRefV1()
+            | CalldataDescriptorPathElementLeafV1()
+        ):
+            path_in = path.elements
+            leaf_slice = None
+        case CalldataDescriptorPathElementSliceV1() as s:
+            path_in = path.elements[:-1]
+            leaf_slice = s
+        case _:
+            assert_never(path.elements[-1])
+
+    offset = 0
+    ref_offset = 0
+
+    for element in path_in:
+        match element:
+            case CalldataDescriptorPathElementTupleV1():
+                ref_offset = offset
+                offset += element.offset * 32
+
+            case CalldataDescriptorPathElementArrayV1():
+                ref_offset = offset
+                array_length = int.from_bytes(argdata[offset : offset + 32], byteorder="big")
+
+                start = 0 if element.start is None else element.start
+                if start < 0:
+                    start += array_length
+
+                end = array_length if element.end is None else element.end
+                if end < 0:
+                    end += array_length
+
+                if start >= array_length or start < 0:
+                    raise IndexError(f"Array index {element.start} out of bounds")
+
+                if end > array_length or end <= 0:
+                    raise IndexError(f"Array index {element.end} out of bounds")
+
+                if start != end - 1:
+                    raise NotImplementedError("Only array slices of length 1 are supported by this implementation")
+
+                offset += 32 + start * element.weight * 32
+
+            case CalldataDescriptorPathElementRefV1():
+                offset = ref_offset + int.from_bytes(argdata[offset : offset + 32], byteorder="big")
+
+            case CalldataDescriptorPathElementSliceV1():
+                raise ValueError("Slice can only be used as last element of the path")
+
+            case CalldataDescriptorPathElementLeafV1():
+                match element.leaf_type:
+                    case CalldataDescriptorPathLeafType.ARRAY_LEAF:
+                        raise NotImplementedError("Array leaf is not supported in v1 of protocol")
+
+                    case CalldataDescriptorPathLeafType.TUPLE_LEAF:
+                        raise NotImplementedError("Tuple leaf is not supported in v1 of protocol")
+
+                    case CalldataDescriptorPathLeafType.STATIC_LEAF:
+                        # TODO slice ? https://github.com/LedgerHQ/generic_parser/pull/9
+                        return argdata[offset : offset + 32]
+
+                    case CalldataDescriptorPathLeafType.DYNAMIC_LEAF:
+                        length = int.from_bytes(argdata[offset : offset + 32], byteorder="big")
+
+                        if leaf_slice is None:
+                            return argdata[offset + 32 : offset + 32 + length]
+
+                        leaf_slice_start = 0 if leaf_slice.start is None else leaf_slice.start
+                        start = leaf_slice_start if leaf_slice_start >= 0 else length + leaf_slice_start
+
+                        leaf_slice_end = length - 1 if leaf_slice.end is None else leaf_slice.end
+                        end = leaf_slice_end if leaf_slice_end >= 0 else length + leaf_slice_end
+
+                        if start < 0 or end < 0 or start >= length or end >= length:
+                            raise IndexError("Slice out of bounds")
+
+                        return argdata[offset + 32 + start : offset + 32 + end]
+
+                    case _:
+                        assert_never(element.leaf_type)
+
+            case _:
+                assert_never(element)
+
+    raise ValueError("Path did not resolve to a leaf element")

--- a/src/erc7730/convert/calldata/v1/selector.py
+++ b/src/erc7730/convert/calldata/v1/selector.py
@@ -1,0 +1,102 @@
+"""
+Conversion of an ERC-7730 descriptor to a calldata descriptor (for a single chain + selector).
+"""
+
+import hashlib
+from typing import cast
+
+from eth_typing import ChainId as EthChainId
+from pydantic_string_url import HttpUrl
+
+from erc7730.common.binary import from_hex
+from erc7730.common.ledger import ledger_network_id
+from erc7730.common.options import first_not_none
+from erc7730.common.output import OutputAdder
+from erc7730.convert.calldata.v1.abi import function_to_abi_tree
+from erc7730.convert.calldata.v1.enum import convert_enums
+from erc7730.convert.calldata.v1.field import convert_field
+from erc7730.model.abi import Function
+from erc7730.model.calldata.descriptor import (
+    CalldataDescriptor,
+    CalldataDescriptorV1,
+)
+from erc7730.model.calldata.v1.instruction import (
+    CalldataDescriptorInstructionTransactionInfoV1,
+)
+from erc7730.model.resolved.context import ResolvedDeployment
+from erc7730.model.resolved.descriptor import ResolvedERC7730Descriptor
+from erc7730.model.resolved.display import ResolvedFormat
+from erc7730.model.types import Selector
+
+
+def convert_selector(
+    descriptor: ResolvedERC7730Descriptor,
+    deployment: ResolvedDeployment,
+    selector: Selector,
+    format: ResolvedFormat,
+    abi: Function,
+    source: HttpUrl | None,
+    out: OutputAdder,
+) -> CalldataDescriptor | None:
+    """
+    Generate output calldata descriptor for a single selector ("format" in ERC-7730 source descriptor).
+
+    If descriptor is invalid, None is returned. Errors are logged to the console.
+
+    :param descriptor: resolved source ERC-7730 descriptor
+    :param deployment: chain id / contract address for which the descriptor is generated
+    :param selector: function for which the descriptor is generated
+    :param format: ERC-7730 format for the selector
+    :param abi: ABI of the function
+    :param source: source of the descriptor file
+    :param out: error handler
+    :return: output calldata descriptors (1 per chain + selector)
+    """
+
+    abi_tree = function_to_abi_tree(abi)
+
+    creator_legal_name: str | None = None
+    creator_url: str | None = None
+    deploy_date: str | None = None
+    if (owner_info := descriptor.metadata.info) is not None:
+        creator_legal_name = owner_info.legalName
+        creator_url = owner_info.url
+        deploy_date = owner_info.deploymentDate.strftime("%Y-%m-%dT%H:%M:%SZ") if owner_info.deploymentDate else None
+
+    enums = convert_enums(deployment, selector, descriptor.metadata.enums)
+
+    enums_by_id = {enum.enum_id: enum.id for enum in enums}
+
+    fields = []
+    for input_field in format.fields:
+        if (output_fields := convert_field(abi=abi_tree, field=input_field, enums=enums_by_id, out=out)) is None:
+            return None
+        fields.extend(output_fields)
+
+    hash = hashlib.sha3_256()
+    for field in fields:
+        hash.update(from_hex(field.descriptor))
+
+    transaction_info = CalldataDescriptorInstructionTransactionInfoV1(
+        chain_id=EthChainId(deployment.chainId),
+        address=deployment.address,
+        selector=selector,
+        hash=hash.digest().hex(),
+        operation_type=first_not_none(format.intent, format.id, selector),  # type:ignore
+        creator_name=descriptor.metadata.owner,
+        creator_legal_name=creator_legal_name,
+        creator_url=creator_url,
+        contract_name=descriptor.context.id,
+        deploy_date=deploy_date,
+    )
+
+    return CalldataDescriptorV1(
+        source=source,
+        network=cast(str, ledger_network_id(deployment.chainId)),
+        chain_id=EthChainId(deployment.chainId),
+        address=deployment.address,
+        selector=selector,
+        transaction_info=transaction_info,
+        enums=enums,
+        fields=fields,
+    )

--- a/src/erc7730/convert/calldata/v1/tlv.py
+++ b/src/erc7730/convert/calldata/v1/tlv.py
@@ -1,0 +1,516 @@
+"""
+Encoding of calldata descriptor instructions to TLV format.
+
+See https://github.com/LedgerHQ/generic_parser for specifications of these payloads.
+"""
+
+from datetime import datetime
+from enum import IntEnum
+from typing import assert_never
+
+from erc7730.common.binary import from_hex, tlv
+from erc7730.common.pydantic import pydantic_enum_by_name
+from erc7730.model.calldata.types import TrustedNameSource, TrustedNameType
+from erc7730.model.calldata.v1.instruction import (
+    CalldataDescriptorInstructionEnumValueV1,
+    CalldataDescriptorInstructionFieldV1,
+    CalldataDescriptorInstructionTransactionInfoV1,
+)
+from erc7730.model.calldata.v1.param import (
+    CalldataDescriptorParamAmountV1,
+    CalldataDescriptorParamDatetimeV1,
+    CalldataDescriptorParamDurationV1,
+    CalldataDescriptorParamEnumV1,
+    CalldataDescriptorParamNFTV1,
+    CalldataDescriptorParamRawV1,
+    CalldataDescriptorParamTokenAmountV1,
+    CalldataDescriptorParamTrustedNameV1,
+    CalldataDescriptorParamType,
+    CalldataDescriptorParamUnitV1,
+)
+from erc7730.model.calldata.v1.value import (
+    CalldataDescriptorContainerPathV1,
+    CalldataDescriptorDataPathV1,
+    CalldataDescriptorPathElementArrayV1,
+    CalldataDescriptorPathElementLeafV1,
+    CalldataDescriptorPathElementRefV1,
+    CalldataDescriptorPathElementSliceV1,
+    CalldataDescriptorPathElementTupleV1,
+    CalldataDescriptorPathElementV1,
+    CalldataDescriptorValueConstantV1,
+    CalldataDescriptorValuePathV1,
+    CalldataDescriptorValueV1,
+)
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorTransactionInfoTag(IntEnum):
+    VERSION = 0x00
+    CHAIN_ID = 0x01
+    CONTRACT_ADDR = 0x02
+    SELECTOR = 0x03
+    FIELDS_HASH = 0x04
+    OPERATION_TYPE = 0x05
+    CREATOR_NAME = 0x06
+    CREATOR_LEGAL_NAME = 0x07
+    CREATOR_URL = 0x08
+    CONTRACT_NAME = 0x09
+    DEPLOY_DATE = 0x0A
+    SIGNATURE = 0xFF
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorEnumValueTag(IntEnum):
+    VERSION = 0x00
+    CHAIN_ID = 0x01
+    CONTRACT_ADDR = 0x02
+    SELECTOR = 0x03
+    ID = 0x04
+    VALUE = 0x05
+    NAME = 0x06
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorFieldTag(IntEnum):
+    VERSION = 0x00
+    NAME = 0x01
+    PARAM_TYPE = 0x02
+    PARAM = 0x03
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorParamRawTag(IntEnum):
+    VERSION = 0x00
+    VALUE = 0x01
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorParamAmountTag(IntEnum):
+    VERSION = 0x00
+    VALUE = 0x01
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorParamTokenAmountTag(IntEnum):
+    VERSION = 0x00
+    VALUE = 0x01
+    TOKEN = 0x02
+    NATIVE_CURRENCY = 0x03
+    THRESHOLD = 0x04
+    ABOVE_THRESHOLD_MSG = 0x05
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorParamNFTTag(IntEnum):
+    VERSION = 0x00
+    VALUE = 0x01
+    COLLECTION = 0x02
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorParamDateTimeTag(IntEnum):
+    VERSION = 0x00
+    VALUE = 0x01
+    TYPE = 0x02
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorParamDurationTag(IntEnum):
+    VERSION = 0x00
+    VALUE = 0x01
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorParamUnitTag(IntEnum):
+    VERSION = 0x00
+    VALUE = 0x01
+    BASE = 0x02
+    DECIMALS = 0x03
+    PREFIX = 0x04
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorParamEnumTag(IntEnum):
+    VERSION = 0x00
+    ID = 0x01
+    VALUE = 0x02
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorParamTrustedNameTag(IntEnum):
+    VERSION = 0x00
+    VALUE = 0x01
+    TYPES = 0x02
+    SOURCES = 0x03
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorValueTag(IntEnum):
+    VERSION = 0x00
+    TYPE_FAMILY = 0x01
+    TYPE_SIZE = 0x02
+    DATA_PATH = 0x03
+    CONTAINER_PATH = 0x04
+    CONSTANT = 0x05
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorPathElementTag(IntEnum):
+    VERSION = 0x00
+    TUPLE = 0x01
+    ARRAY = 0x02
+    REF = 0x03
+    LEAF = 0x04
+    SLICE = 0x05
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorPathArrayElementTag(IntEnum):
+    WEIGHT = 0x01
+    START = 0x02
+    END = 0x03
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorPathSliceElementTag(IntEnum):
+    START = 0x01
+    END = 0x02
+
+
+def tlv_transaction_info(obj: CalldataDescriptorInstructionTransactionInfoV1) -> bytes:
+    """
+    Encode a struct of type TRANSACTION_INFO.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorTransactionInfoTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorTransactionInfoTag.CHAIN_ID, obj.chain_id.to_bytes(8))
+    out += tlv(CalldataDescriptorTransactionInfoTag.CONTRACT_ADDR, from_hex(obj.address))
+    out += tlv(CalldataDescriptorTransactionInfoTag.SELECTOR, from_hex(obj.selector))
+    out += tlv(CalldataDescriptorTransactionInfoTag.FIELDS_HASH, from_hex(obj.hash))
+    out += tlv(CalldataDescriptorTransactionInfoTag.OPERATION_TYPE, obj.operation_type)
+
+    if (creator_name := obj.creator_name) is not None:
+        out += tlv(CalldataDescriptorTransactionInfoTag.CREATOR_NAME, creator_name)
+
+    if (creator_legal_name := obj.creator_legal_name) is not None:
+        out += tlv(CalldataDescriptorTransactionInfoTag.CREATOR_LEGAL_NAME, creator_legal_name)
+
+    if (creator_url := obj.creator_url) is not None:
+        out += tlv(CalldataDescriptorTransactionInfoTag.CREATOR_URL, creator_url)
+
+    if (contract_name := obj.contract_name) is not None:
+        out += tlv(CalldataDescriptorTransactionInfoTag.CONTRACT_NAME, contract_name)
+
+    if (deploy_date := obj.deploy_date) is not None:
+        tstamp = int(datetime.fromisoformat(deploy_date).timestamp())
+        out += tlv(CalldataDescriptorTransactionInfoTag.DEPLOY_DATE, tstamp.to_bytes(4))
+
+    return out
+
+
+def tlv_enum_value(obj: CalldataDescriptorInstructionEnumValueV1) -> bytes:
+    """
+    Encode a struct of type ENUM_VALUE.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorEnumValueTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorEnumValueTag.CHAIN_ID, obj.chain_id.to_bytes(8))
+    out += tlv(CalldataDescriptorEnumValueTag.CONTRACT_ADDR, from_hex(obj.address))
+    out += tlv(CalldataDescriptorEnumValueTag.SELECTOR, from_hex(obj.selector))
+    out += tlv(CalldataDescriptorEnumValueTag.ID, obj.id.to_bytes(1))
+    out += tlv(CalldataDescriptorEnumValueTag.VALUE, obj.value.to_bytes(1))
+    out += tlv(CalldataDescriptorEnumValueTag.NAME, obj.name)
+    return out
+
+
+def tlv_field(obj: CalldataDescriptorInstructionFieldV1) -> bytes:
+    """
+    Encode a struct of type FIELD.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorFieldTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorFieldTag.NAME, obj.name)
+
+    param_type: CalldataDescriptorParamType
+    param_value: bytes
+    match obj.param:
+        case CalldataDescriptorParamRawV1():
+            param_type = CalldataDescriptorParamType.RAW
+            param_value = tlv_param_raw(obj.param)
+        case CalldataDescriptorParamAmountV1():
+            param_type = CalldataDescriptorParamType.AMOUNT
+            param_value = tlv_param_amount(obj.param)
+        case CalldataDescriptorParamTokenAmountV1():
+            param_type = CalldataDescriptorParamType.TOKEN_AMOUNT
+            param_value = tlv_param_token_amount(obj.param)
+        case CalldataDescriptorParamNFTV1():
+            param_type = CalldataDescriptorParamType.NFT
+            param_value = tlv_param_nft(obj.param)
+        case CalldataDescriptorParamDatetimeV1():
+            param_type = CalldataDescriptorParamType.DATETIME
+            param_value = tlv_param_datetime(obj.param)
+        case CalldataDescriptorParamDurationV1():
+            param_type = CalldataDescriptorParamType.DURATION
+            param_value = tlv_param_duration(obj.param)
+        case CalldataDescriptorParamUnitV1():
+            param_type = CalldataDescriptorParamType.UNIT
+            param_value = tlv_param_unit(obj.param)
+        case CalldataDescriptorParamEnumV1():
+            param_type = CalldataDescriptorParamType.ENUM
+            param_value = tlv_param_enum(obj.param)
+        case CalldataDescriptorParamTrustedNameV1():
+            param_type = CalldataDescriptorParamType.TRUSTED_NAME
+            param_value = tlv_param_trusted_name(obj.param)
+        case _:
+            assert_never(obj.param)
+
+    out += tlv(CalldataDescriptorFieldTag.PARAM_TYPE, param_type.value.to_bytes(1))
+    out += tlv(CalldataDescriptorFieldTag.PARAM, param_value)
+
+    return out
+
+
+def tlv_param_raw(obj: CalldataDescriptorParamRawV1) -> bytes:
+    """
+    Encode a struct of type PARAM_RAW.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorParamRawTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorParamRawTag.VALUE, tlv_value(obj.value))
+    return out
+
+
+def tlv_param_amount(obj: CalldataDescriptorParamAmountV1) -> bytes:
+    """
+    Encode a struct of type PARAM_AMOUNT.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorParamAmountTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorParamAmountTag.VALUE, tlv_value(obj.value))
+    return out
+
+
+def tlv_param_token_amount(obj: CalldataDescriptorParamTokenAmountV1) -> bytes:
+    """
+    Encode a struct of type PARAM_TOKEN_AMOUNT.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorParamTokenAmountTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorParamTokenAmountTag.VALUE, tlv_value(obj.value))
+
+    if (token := obj.token) is not None:
+        out += tlv(CalldataDescriptorParamTokenAmountTag.TOKEN, tlv_value(token))
+
+    if (native_currencies := obj.native_currencies) is not None:
+        for currency in native_currencies:
+            out += tlv(CalldataDescriptorParamTokenAmountTag.NATIVE_CURRENCY, from_hex(currency))
+
+    if (threshold := obj.threshold) is not None:
+        out += tlv(CalldataDescriptorParamTokenAmountTag.THRESHOLD, from_hex(threshold))
+
+    if (above_threshold_message := obj.above_threshold_message) is not None:
+        out += tlv(CalldataDescriptorParamTokenAmountTag.ABOVE_THRESHOLD_MSG, above_threshold_message)
+
+    return out
+
+
+def tlv_param_nft(obj: CalldataDescriptorParamNFTV1) -> bytes:
+    """
+    Encode a struct of type PARAM_NFT.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorParamNFTTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorParamNFTTag.VALUE, tlv_value(obj.value))
+    out += tlv(CalldataDescriptorParamNFTTag.COLLECTION, tlv_value(obj.collection))
+    return out
+
+
+def tlv_param_datetime(obj: CalldataDescriptorParamDatetimeV1) -> bytes:
+    """
+    Encode a struct of type PARAM_DATETIME.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorParamDateTimeTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorParamDateTimeTag.VALUE, tlv_value(obj.value))
+    out += tlv(CalldataDescriptorParamDateTimeTag.TYPE, obj.date_type.to_bytes(1))
+    return out
+
+
+def tlv_param_duration(obj: CalldataDescriptorParamDurationV1) -> bytes:
+    """
+    Encode a struct of type PARAM_DURATION.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorParamDurationTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorParamDurationTag.VALUE, tlv_value(obj.value))
+    return out
+
+
+def tlv_param_unit(obj: CalldataDescriptorParamUnitV1) -> bytes:
+    """
+    Encode a struct of type PARAM_UNIT.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorParamUnitTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorParamUnitTag.VALUE, tlv_value(obj.value))
+    out += tlv(CalldataDescriptorParamUnitTag.BASE, obj.base)
+
+    if (decimals := obj.decimals) is not None:
+        out += tlv(CalldataDescriptorParamUnitTag.DECIMALS, decimals.to_bytes(1))
+
+    if (prefix := obj.prefix) is not None:
+        out += tlv(CalldataDescriptorParamUnitTag.PREFIX, prefix.to_bytes(1))
+
+    return out
+
+
+def tlv_param_enum(obj: CalldataDescriptorParamEnumV1) -> bytes:
+    """
+    Encode a struct of type PARAM_ENUM.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorParamEnumTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorParamEnumTag.VALUE, tlv_value(obj.value))
+    out += tlv(CalldataDescriptorParamEnumTag.ID, obj.id.to_bytes(1))
+    return out
+
+
+def tlv_param_trusted_name(obj: CalldataDescriptorParamTrustedNameV1) -> bytes:
+    """
+    Encode a struct of type PARAM_TRUSTED_NAME.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorParamTrustedNameTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorParamTrustedNameTag.VALUE, tlv_value(obj.value))
+
+    out_types = bytearray()
+    for name_type in obj.types:
+        out_types += TrustedNameType(name_type).int_value.to_bytes(1)
+    out += tlv(CalldataDescriptorParamTrustedNameTag.TYPES, out_types)
+
+    out_sources = bytearray()
+    for name_source in obj.sources:
+        out_sources += TrustedNameSource(name_source).int_value.to_bytes(1)
+    out += tlv(CalldataDescriptorParamTrustedNameTag.SOURCES, out_sources)
+
+    return out
+
+
+def tlv_value(obj: CalldataDescriptorValueV1) -> bytes:
+    """
+    Encode a struct of type VALUE.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorValueTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorValueTag.TYPE_FAMILY, obj.type_family.value.to_bytes(1))
+
+    if (type_size := obj.type_size) is not None:
+        try:
+            out += tlv(CalldataDescriptorValueTag.TYPE_SIZE, type_size.to_bytes(1))
+        except OverflowError:
+            raise OverflowError(f"Type {obj.type_family} with size {type_size} bits is too big to convert") from None
+
+    match obj:
+        case CalldataDescriptorValuePathV1() as path:
+            match path.binary_path:
+                case CalldataDescriptorContainerPathV1() as container_path:
+                    out += tlv(CalldataDescriptorValueTag.CONTAINER_PATH, container_path.value.to_bytes(1))
+                case CalldataDescriptorDataPathV1() as data_path:
+                    out_path = bytearray()
+                    out_path += tlv(CalldataDescriptorPathElementTag.VERSION, path.version.to_bytes(1))
+                    for element in data_path.elements:
+                        out_path += tlv_data_path_element(element)
+                    out += tlv(CalldataDescriptorValueTag.DATA_PATH, out_path)
+                case _:
+                    assert_never(path.binary_path)
+        case CalldataDescriptorValueConstantV1() as constant:
+            out += tlv(CalldataDescriptorValueTag.CONSTANT, from_hex(constant.raw))
+        case _:
+            assert_never(obj)
+
+    return out
+
+
+def tlv_data_path_element(obj: CalldataDescriptorPathElementV1) -> bytes:
+    """
+    Encode a struct of type PATH_ELEMENT.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    match obj:
+        case CalldataDescriptorPathElementTupleV1() as tup:
+            out += tlv(CalldataDescriptorPathElementTag.TUPLE, tup.offset.to_bytes(2))
+
+        case CalldataDescriptorPathElementArrayV1() as arr:
+            array_out = bytearray()
+            array_out += tlv(CalldataDescriptorPathArrayElementTag.WEIGHT, arr.weight.to_bytes(1))
+
+            if (start := arr.start) is not None:
+                array_out += tlv(CalldataDescriptorPathArrayElementTag.START, start.to_bytes(2, signed=True))
+
+            if (end := arr.end) is not None:
+                array_out += tlv(CalldataDescriptorPathArrayElementTag.END, end.to_bytes(2, signed=True))
+
+            out += tlv(CalldataDescriptorPathElementTag.ARRAY, bytes(array_out))
+
+        case CalldataDescriptorPathElementRefV1():
+            out += tlv(CalldataDescriptorPathElementTag.REF)
+
+        case CalldataDescriptorPathElementLeafV1() as leaf:
+            out += tlv(CalldataDescriptorPathElementTag.LEAF, leaf.leaf_type.value.to_bytes(1))
+
+        case CalldataDescriptorPathElementSliceV1() as slice:
+            slice_out = bytearray()
+
+            if (start := slice.start) is not None:
+                slice_out += tlv(CalldataDescriptorPathSliceElementTag.START, start.to_bytes(2, signed=True))
+
+            if (end := slice.end) is not None:
+                slice_out += tlv(CalldataDescriptorPathSliceElementTag.END, end.to_bytes(2, signed=True))
+
+            out += tlv(CalldataDescriptorPathElementTag.SLICE, bytes(slice_out))
+
+        case _:
+            assert_never(obj)
+    return out

--- a/src/erc7730/model/calldata/__init__.py
+++ b/src/erc7730/model/calldata/__init__.py
@@ -1,0 +1,67 @@
+"""
+Data model for Ledger specific calldata descriptor (also referred to as "generic parser" descriptor).
+
+See documentation in https://github.com/LedgerHQ/app-ethereum for specifications of this protocol
+
+This data model is exposed in the public API and used by client applications to interact with the Ethereum application
+using the generic parser protocol.
+"""
+
+from abc import ABC
+from enum import StrEnum, auto
+from typing import Literal
+
+from eth_typing import ChainId as EthChainId
+from pydantic import Field
+from pydantic_string_url import HttpUrl
+
+from erc7730.model.base import Model
+from erc7730.model.types import Address, Id, Selector
+
+
+class CalldataDescriptorVersion(StrEnum):
+    """Version of the calldata descriptor."""
+
+    v1 = auto()
+
+
+class CalldataDescriptorBase(Model, ABC):
+    """
+    A clear signing descriptor for a smart contract function calldata.
+
+    Note a calldata descriptor is bound to a single deployment (single chain id/contract address) and a single function.
+
+    Also referred to as a "generic parser descriptor".
+    """
+
+    type: Literal["calldata"] = Field(
+        default="calldata",
+        title="Descriptor type",
+        description="Type of the descriptor",
+    )
+
+    source: HttpUrl | None = Field(
+        default=None,
+        title="Descriptor source URL",
+        description="The URL of the source of the descriptor (typically in clear-signing-erc7730-registry).",
+    )
+
+    network: Id = Field(
+        title="Ledger Network identifier",
+        description="The Ledger network this descriptor applies to.",
+    )
+
+    chain_id: EthChainId = Field(
+        title="Chain ID",
+        description="The contract deployment EIP-155 chain id.",
+    )
+
+    address: Address = Field(
+        title="Contract address",
+        description="The contract deployment address.",
+    )
+
+    selector: Selector = Field(
+        title="Function selector",
+        description="The 4-bytes function selector this descriptor applies to.",
+    )

--- a/src/erc7730/model/calldata/descriptor.py
+++ b/src/erc7730/model/calldata/descriptor.py
@@ -1,0 +1,26 @@
+"""
+Base data model for Ledger specific calldata descriptor (also referred to as "generic parser" descriptor).
+
+See documentation in https://github.com/LedgerHQ/app-ethereum for specifications of this protocol
+
+This data model is exposed in the public API and used by client applications to interact with the Ethereum application
+using the generic parser protocol.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from erc7730.model.calldata.v1.descriptor import (
+    CalldataDescriptorV1,
+)
+
+CalldataDescriptor = Annotated[
+    CalldataDescriptorV1,
+    Field(
+        title="Calldata descriptor",
+        description="A clear signing descriptor for a smart contract function calldata. Also referred to as a "
+        """"generic parser descriptor".""",
+        discriminator="version",
+    ),
+]

--- a/src/erc7730/model/calldata/types.py
+++ b/src/erc7730/model/calldata/types.py
@@ -1,0 +1,54 @@
+from enum import StrEnum
+
+
+class TrustedNameType(StrEnum):
+    EOA = "eoa"
+    SMART_CONTRACT = "smart_contract"
+    COLLECTION = "collection"
+    TOKEN = "token"  # nosec B105 - bandit false positive
+    WALLET = "wallet"
+    CONTEXT_ADDRESS = "context_address"
+
+    @property
+    def int_value(self) -> int:
+        match self:
+            case TrustedNameType.EOA:
+                return 1
+            case TrustedNameType.SMART_CONTRACT:
+                return 2
+            case TrustedNameType.COLLECTION:
+                return 3
+            case TrustedNameType.TOKEN:
+                return 4
+            case TrustedNameType.WALLET:
+                return 5
+            case TrustedNameType.CONTEXT_ADDRESS:
+                return 6
+
+
+class TrustedNameSource(StrEnum):
+    LOCAL_ADDRESS_BOOK = "local_address_book"
+    CRYPTO_ASSET_LIST = "crypto_asset_list"
+    ENS = "ens"
+    UNSTOPPABLE_DOMAIN = "unstoppable_domain"
+    FREENAME = "freename"
+    DNS = "dns"
+    DYNAMIC_RESOLVER = "dynamic_resolver"
+
+    @property
+    def int_value(self) -> int:
+        match self:
+            case TrustedNameSource.LOCAL_ADDRESS_BOOK:
+                return 0
+            case TrustedNameSource.CRYPTO_ASSET_LIST:
+                return 1
+            case TrustedNameSource.ENS:
+                return 2
+            case TrustedNameSource.UNSTOPPABLE_DOMAIN:
+                return 3
+            case TrustedNameSource.FREENAME:
+                return 4
+            case TrustedNameSource.DNS:
+                return 5
+            case TrustedNameSource.DYNAMIC_RESOLVER:
+                return 6

--- a/src/erc7730/model/calldata/v1/__init__.py
+++ b/src/erc7730/model/calldata/v1/__init__.py
@@ -1,0 +1,13 @@
+"""
+Version 1 of the data model for Ledger specific calldata descriptor (also referred to as "generic parser" descriptor).
+
+See documentation in https://github.com/LedgerHQ/app-ethereum for specifications of this protocol
+
+This data model is exposed in the public API and used by client applications to interact with the Ethereum application
+using the generic parser protocol.
+
+The version 1 of the protocol comes with the following limitations:
+ - Constant/literal values are not supported
+ - Nested array fields are only partially supported
+ - Recursive invocations using fields with "calldata" format are not supported
+"""

--- a/src/erc7730/model/calldata/v1/descriptor.py
+++ b/src/erc7730/model/calldata/v1/descriptor.py
@@ -1,0 +1,44 @@
+"""
+Data model for Ledger specific calldata descriptor, version 1 (also referred to as "generic parser" descriptor).
+"""
+
+from typing import Literal
+
+from pydantic import Field
+
+from erc7730.model.calldata import CalldataDescriptorBase
+from erc7730.model.calldata.v1.instruction import (
+    CalldataDescriptorInstructionEnumValueV1,
+    CalldataDescriptorInstructionFieldV1,
+    CalldataDescriptorInstructionTransactionInfoV1,
+)
+
+
+class CalldataDescriptorV1(CalldataDescriptorBase):
+    """
+    A clear signing descriptor for a smart contract function calldata.
+
+    Also referred to as a "generic parser descriptor".
+    """
+
+    version: Literal["v1"] = Field(
+        default="v1",
+        title="Descriptor type version",
+        description="Version of the descriptor type (not the version of this specific descriptor, the version of the "
+        "descriptor specification)",
+    )
+
+    transaction_info: CalldataDescriptorInstructionTransactionInfoV1 = Field(
+        title="TRANSACTION_INFO instruction descriptor",
+        description="Descriptor and metadata to craft a TRANSACTION_INFO APDU.",
+    )
+
+    enums: list[CalldataDescriptorInstructionEnumValueV1] = Field(
+        title="ENUM_VALUE instructions descriptors",
+        description="Descriptor and metadata to craft ENUM APDUs.",
+    )
+
+    fields: list[CalldataDescriptorInstructionFieldV1] = Field(
+        title="FIELD instructions descriptors",
+        description="Descriptor and metadata to craft FIELD APDUs.",
+    )

--- a/src/erc7730/model/calldata/v1/instruction.py
+++ b/src/erc7730/model/calldata/v1/instruction.py
@@ -1,0 +1,220 @@
+"""
+Data model for calldata descriptor instructions.
+
+These model classes represent the exact same data fields that are serialized into TLV structs.
+See documentation in https://github.com/LedgerHQ/app-ethereum for specifications of this protocol
+"""
+
+from abc import ABC
+from functools import cached_property
+from typing import Annotated, Literal
+
+from eth_typing import ChainId as EthChainId
+from pydantic import Field, computed_field
+from pydantic_string_url import HttpUrl
+
+from erc7730.model.calldata.v1.param import (
+    CalldataDescriptorParamV1,
+)
+from erc7730.model.calldata.v1.struct import (
+    CalldataDescriptorStructV1,
+)
+from erc7730.model.types import Address, HexStr, Selector
+
+CalldataDescriptorInstructionHex = Annotated[
+    HexStr,
+    Field(
+        title="Serialized TLV instruction payload",
+        description="Serialized, hex encoded TLV payload.",
+        min_length=8,
+        max_length=32768,
+    ),
+]
+
+CalldataDescriptorInstructionProtobuf = Annotated[
+    HexStr,
+    Field(
+        title="Serialized production signature payload",
+        description="Serialized, hex encoded Protobuf payload used for production signature.",
+        min_length=8,
+        max_length=32768,
+    ),
+]
+
+
+class CalldataDescriptorInstructionBaseV1(CalldataDescriptorStructV1, ABC):
+    """Base class for calldata descriptor instructions."""
+
+
+class CalldataDescriptorInstructionTransactionInfoV1(CalldataDescriptorInstructionBaseV1):
+    """Instruction descriptor for the TRANSACTION_INFO struct."""
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the TRANSACTION_INFO struct",
+    )
+
+    chain_id: EthChainId = Field(
+        title="Chain ID",
+        description="The contract deployment EIP-155 chain id.",
+    )
+
+    address: Address = Field(
+        title="Contract address",
+        description="The contract deployment address.",
+    )
+
+    selector: Selector = Field(
+        title="Function selector",
+        description="The 4-bytes function selector this descriptor applies to.",
+    )
+
+    hash: str = Field(
+        title="Structs hash",
+        description="Hash of all the FIELD structs",
+        pattern=r"^[a-f0-9]+$",
+        min_length=64,
+        max_length=64,
+    )
+
+    operation_type: str = Field(
+        title="Operation type",
+        description="Displayed in review first screens",
+        min_length=1,
+        max_length=32,  # TODO to be refined
+    )
+
+    creator_name: str | None = Field(
+        default=None,
+        title="Creator name",
+        description="Displayed in review first screens",
+        min_length=1,
+        max_length=32,  # TODO to be refined
+    )
+
+    creator_legal_name: str | None = Field(
+        default=None,
+        title="Creator legal name",
+        description="Displayed in review first screens",
+        min_length=1,
+        max_length=32,  # TODO to be refined
+    )
+
+    creator_url: HttpUrl | None = Field(
+        default=None,
+        title="Creator URL",
+        description="Displayed in review first screens",
+        min_length=1,
+        max_length=256,  # TODO to be refined
+    )
+
+    contract_name: str | None = Field(
+        default=None,
+        title="Contract name",
+        description="Displayed in review first screens",
+        min_length=1,
+        max_length=32,  # TODO to be refined
+    )
+
+    deploy_date: str | None = Field(
+        default=None,
+        title="Deploy date",
+        description="Displayed in review first screens",
+    )
+
+    @computed_field(title="Descriptor", description="Hex encoded TRANSACTION_INFO TLV struct")  # type: ignore[misc]
+    @cached_property
+    def descriptor(self) -> CalldataDescriptorInstructionHex:
+        from erc7730.convert.calldata.v1.tlv import (
+            tlv_transaction_info,
+        )
+
+        return tlv_transaction_info(self).hex()
+
+
+class CalldataDescriptorInstructionEnumValueV1(CalldataDescriptorInstructionBaseV1):
+    """Instruction descriptor for the ENUM_VALUE struct."""
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the ENUM struct",
+    )
+
+    chain_id: EthChainId = Field(
+        title="Chain ID",
+        description="The contract deployment EIP-155 chain id.",
+    )
+
+    address: Address = Field(
+        title="Contract address",
+        description="The contract deployment address.",
+    )
+
+    selector: Selector = Field(
+        title="Function selector",
+        description="The 4-bytes function selector this descriptor applies to.",
+    )
+
+    enum_id: str = Field(
+        title="Source enum identifier",
+        description="Source identifier of the enum (to differentiate multiple enums in one contract)",
+    )
+
+    id: int = Field(
+        title="Enum identifier",
+        description="Identifier of the enum (to differentiate multiple enums in one contract)",
+        ge=0,
+        le=255,
+    )
+
+    value: int = Field(
+        title="Enum entry value",
+        description="Identifier of this specific entry (ordinal of the entry, type agnostic)",
+        ge=0,
+        le=32,
+    )
+
+    name: str = Field(
+        title="Enum entry name",
+        description="Enum display name (ASCII)",
+        min_length=1,
+        max_length=32,  # TODO to be refined
+    )
+
+    @computed_field(title="Descriptor", description="Hex encoded ENUM TLV struct")  # type: ignore[misc]
+    @cached_property
+    def descriptor(self) -> CalldataDescriptorInstructionHex:
+        from erc7730.convert.calldata.v1.tlv import tlv_enum_value
+
+        return tlv_enum_value(self).hex()
+
+
+class CalldataDescriptorInstructionFieldV1(CalldataDescriptorInstructionBaseV1):
+    """Instruction descriptor for the FIELD struct."""
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the FIELD struct",
+    )
+
+    name: str = Field(
+        title="Field name",
+        description="Field display name (ASCII)",
+        min_length=1,
+        max_length=32,  # TODO to be refined
+    )
+
+    param: CalldataDescriptorParamV1 = Field(
+        title="Field parameter",
+        description="Parameter of the field",
+    )
+
+    @computed_field(title="Descriptor", description="Hex encoded FIELD TLV struct")  # type: ignore[misc]
+    @cached_property
+    def descriptor(self) -> CalldataDescriptorInstructionHex:
+        from erc7730.convert.calldata.v1.tlv import tlv_field
+
+        return tlv_field(self).hex()

--- a/src/erc7730/model/calldata/v1/param.py
+++ b/src/erc7730/model/calldata/v1/param.py
@@ -1,0 +1,284 @@
+"""
+Data model for calldata descriptor field parameters.
+
+These model classes represent the exact same data fields that are serialized into TLV structs.
+See documentation in https://github.com/LedgerHQ/app-ethereum for specifications of this protocol
+"""
+
+from abc import ABC
+from enum import IntEnum
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from erc7730.model.calldata.types import TrustedNameSource, TrustedNameType
+from erc7730.model.calldata.v1.struct import (
+    CalldataDescriptorStructV1,
+)
+from erc7730.model.calldata.v1.value import (
+    CalldataDescriptorValueV1,
+)
+from erc7730.model.types import Address, HexStr
+
+
+class CalldataDescriptorParamType(IntEnum):
+    """Type of calldata field parameters."""
+
+    RAW = 0x00
+    AMOUNT = 0x01
+    TOKEN_AMOUNT = 0x02
+    NFT = 0x03
+    DATETIME = 0x04
+    DURATION = 0x05
+    UNIT = 0x06
+    ENUM = 0x07
+    TRUSTED_NAME = 0x08
+    CALLDATA = 0x09
+
+
+class CalldataDescriptorDateType(IntEnum):
+    """Type of date formatting."""
+
+    UNIX = 0x00
+    BLOCK_HEIGHT = 0x01
+
+
+class CalldataDescriptorParamBaseV1(CalldataDescriptorStructV1, ABC):
+    """Base class for calldata descriptor PARAM_* structs."""
+
+    value: CalldataDescriptorValueV1 = Field(
+        title="Parameter value", description="Reference to value to display (as a path in serialized data)"
+    )
+
+
+class CalldataDescriptorParamRawV1(CalldataDescriptorParamBaseV1):
+    """Descriptor for the PARAM_RAW struct."""
+
+    type: Literal["RAW"] = Field(
+        default="RAW",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the PARAM_RAW struct",
+    )
+
+
+class CalldataDescriptorParamAmountV1(CalldataDescriptorParamBaseV1):
+    """Descriptor for the PARAM_AMOUNT struct."""
+
+    type: Literal["AMOUNT"] = Field(
+        default="AMOUNT",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the PARAM_AMOUNT struct",
+    )
+
+
+class CalldataDescriptorParamTokenAmountV1(CalldataDescriptorParamBaseV1):
+    """Descriptor for the PARAM_TOKEN_AMOUNT struct."""
+
+    type: Literal["TOKEN_AMOUNT"] = Field(
+        default="TOKEN_AMOUNT",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the PARAM_TOKEN_AMOUNT struct",
+    )
+
+    token: CalldataDescriptorValueV1 | None = Field(
+        default=None,
+        title="Token address value",
+        description="Reference to token address (as a path in serialized data)",
+    )
+
+    native_currencies: list[Address] | None = Field(
+        default=None, title="Native currencies", description="Addresses to interpret as native currency"
+    )
+
+    threshold: HexStr | None = Field(
+        default=None,
+        title="Unlimited amount threshold",
+        description="Amount threshold to display as unlimited amount",
+    )
+
+    above_threshold_message: str | None = Field(
+        default=None,
+        title="Unlimited amount message",
+        description="Label to display for unlimited amount",
+        min_length=1,
+        max_length=32,  # TODO to be refined
+    )
+
+
+class CalldataDescriptorParamNFTV1(CalldataDescriptorParamBaseV1):
+    """Descriptor for the PARAM_NFT struct."""
+
+    type: Literal["NFT"] = Field(
+        default="NFT",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the PARAM_NFT struct",
+    )
+
+    collection: CalldataDescriptorValueV1 = Field(
+        title="Collection address value",
+        description="Reference to the collection address (as a path in serialized data)",
+    )
+
+
+class CalldataDescriptorParamDatetimeV1(CalldataDescriptorParamBaseV1):
+    """Descriptor for the PARAM_DATETIME struct."""
+
+    type: Literal["DATETIME"] = Field(
+        default="DATETIME",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the PARAM_DATETIME struct",
+    )
+
+    date_type: CalldataDescriptorDateType = Field(
+        title="Date type",
+        description="Type of date formatting",
+    )
+
+
+class CalldataDescriptorParamDurationV1(CalldataDescriptorParamBaseV1):
+    """Descriptor for the PARAM_DURATION struct."""
+
+    type: Literal["DURATION"] = Field(
+        default="DURATION",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the PARAM_DURATION struct",
+    )
+
+
+class CalldataDescriptorParamUnitV1(CalldataDescriptorParamBaseV1):
+    """Descriptor for the PARAM_UNIT struct."""
+
+    type: Literal["UNIT"] = Field(
+        default="UNIT",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the PARAM_UNIT struct",
+    )
+
+    base: str = Field(
+        title="Unit base symbol",
+        description="The base symbol of the unit, displayed after the converted value. It can be an SI unit symbol or "
+        "acceptable dimensionless symbols like % or bps.",
+        min_length=1,
+        max_length=32,  # TODO to be refined
+    )
+
+    decimals: int | None = Field(
+        default=None,
+        title="Decimals",
+        description="The number of decimals of the value, used to convert to a float.",
+        ge=0,
+        le=255,
+    )
+
+    prefix: bool | None = Field(
+        default=None,
+        title="Prefix",
+        description="Whether the value should be converted to a prefixed unit, like k, M, G, etc.",
+    )
+
+
+class CalldataDescriptorParamEnumV1(CalldataDescriptorParamBaseV1):
+    """Descriptor for the PARAM_ENUM struct."""
+
+    type: Literal["ENUM"] = Field(
+        default="ENUM",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the PARAM_ENUM struct",
+    )
+
+    id: int = Field(
+        title="Enum identifier",
+        description="Identifier of the enum (to differentiate multiple enums in one contract)",
+        ge=0,
+        le=255,
+    )
+
+
+class CalldataDescriptorParamTrustedNameV1(CalldataDescriptorParamBaseV1):
+    """Descriptor for the PARAM_TRUSTED_NAME struct."""
+
+    type: Literal["TRUSTED_NAME"] = Field(
+        default="TRUSTED_NAME",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the PARAM_TRUSTED_NAME struct",
+    )
+
+    types: list[TrustedNameType] = Field(
+        title="Allowed types", description="Allowed types for trusted names display", min_length=1
+    )
+
+    sources: list[TrustedNameSource] = Field(
+        title="Allowed sources", description="Allowed sources for trusted names display", min_length=1
+    )
+
+
+CalldataDescriptorParamV1 = Annotated[
+    CalldataDescriptorParamRawV1
+    | CalldataDescriptorParamAmountV1
+    | CalldataDescriptorParamTokenAmountV1
+    | CalldataDescriptorParamNFTV1
+    | CalldataDescriptorParamDatetimeV1
+    | CalldataDescriptorParamDurationV1
+    | CalldataDescriptorParamUnitV1
+    | CalldataDescriptorParamEnumV1
+    | CalldataDescriptorParamTrustedNameV1,
+    Field(
+        title="Field parameter",
+        description="Format specific parameters for a calldata descriptor field.",
+        discriminator="type",
+    ),
+]

--- a/src/erc7730/model/calldata/v1/struct.py
+++ b/src/erc7730/model/calldata/v1/struct.py
@@ -1,0 +1,22 @@
+"""
+Common data model for all calldata descriptor structs.
+
+See documentation in https://github.com/LedgerHQ/app-ethereum for specifications of this protocol
+"""
+
+from abc import ABC
+
+from pydantic import Field
+
+from erc7730.model.base import Model
+
+
+class CalldataDescriptorStructV1(Model, ABC):
+    """Base class for calldata descriptor structs."""
+
+    version: int = Field(
+        title="Struct version",
+        description="Version of the struct",
+        ge=0,
+        le=255,
+    )

--- a/src/erc7730/model/calldata/v1/value.py
+++ b/src/erc7730/model/calldata/v1/value.py
@@ -1,0 +1,304 @@
+"""
+Data model for calldata descriptor references to values (a.k.a., binary paths).
+
+These model classes represent the exact same data fields that are serialized into TLV structs.
+See documentation in https://github.com/LedgerHQ/app-ethereum for specifications of this protocol
+"""
+
+from enum import IntEnum
+from typing import Annotated, Literal
+
+from pydantic import Discriminator, Field
+
+from erc7730.common.pydantic import pydantic_enum_by_name
+from erc7730.model.base import Model
+from erc7730.model.calldata.v1.struct import (
+    CalldataDescriptorStructV1,
+)
+from erc7730.model.resolved.path import ResolvedPath
+from erc7730.model.types import HexStr, ScalarType
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorPathElementType(IntEnum):
+    """Type of path element."""
+
+    TUPLE = 0x01
+    """move by {value} slots from current slot"""
+
+    ARRAY = 0x02
+    """current slot is array length, added to offset if negative. multiple by item_size and move by result slots"""
+
+    REF = 0x03
+    """read value of current slot. apply read value as offset from current slot"""
+
+    LEAF = 0x04
+    """current slot is a leaf type, specifying the type of path end"""
+
+    SLICE = 0x05
+    """specify slicing to apply to final leaf value as (start, end)"""
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorPathLeafType(IntEnum):
+    """Type of path leaf element."""
+
+    ARRAY_LEAF = 0x01
+    """final offset is start of array encoding"""
+
+    TUPLE_LEAF = 0x02
+    """final offset is start of tuple encoding"""
+
+    STATIC_LEAF = 0x03
+    """final offset contains static encoded value (typ data on 32 bytes)"""
+
+    DYNAMIC_LEAF = 0x04
+    """final offset contains dynamic encoded value (typ length + data)"""
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorTypeFamily(IntEnum):
+    """Type family of a value."""
+
+    UINT = 0x01
+    INT = 0x02
+    UFIXED = 0x03
+    FIXED = 0x04
+    ADDRESS = 0x05
+    BOOL = 0x06
+    BYTES = 0x07
+    STRING = 0x08
+
+
+@pydantic_enum_by_name
+class CalldataDescriptorContainerPathValueV1(IntEnum):
+    """Type of container paths."""
+
+    FROM = 0x0
+    TO = 0x1
+    VALUE = 0x2
+
+
+class CalldataDescriptorPathElementBaseV1(Model):
+    """Descriptor for the PATH_ELEMENT payload."""
+
+
+class CalldataDescriptorPathElementTupleV1(CalldataDescriptorPathElementBaseV1):
+    """Descriptor for the PATH_ELEMENT struct of type TUPLE."""
+
+    type: Literal["TUPLE"] = Field(
+        default="TUPLE",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    offset: int = Field(
+        title="Index",
+        description="Move by {value} slots from current slot",
+    )
+
+
+class CalldataDescriptorPathElementArrayV1(CalldataDescriptorPathElementBaseV1):
+    """Descriptor for the PATH_ELEMENT struct of type ARRAY."""
+
+    type: Literal["ARRAY"] = Field(
+        default="ARRAY",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    weight: int = Field(
+        title="Item size",
+        description="Size of each array element in chunks",
+    )
+
+    start: int | None = Field(
+        title="Start",
+        description="Start offset in array (inclusive). If not provided, lower bound is array start.",
+    )
+
+    end: int | None = Field(
+        title="End",
+        description="End offset in array (exclusive). If not provided, upper bound is array end.",
+    )
+
+
+class CalldataDescriptorPathElementRefV1(CalldataDescriptorPathElementBaseV1):
+    """Descriptor for the PATH_ELEMENT struct of type REF."""
+
+    type: Literal["REF"] = Field(
+        default="REF",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+
+class CalldataDescriptorPathElementLeafV1(CalldataDescriptorPathElementBaseV1):
+    """Descriptor for the PATH_ELEMENT struct of type LEAF."""
+
+    type: Literal["LEAF"] = Field(
+        default="LEAF",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    leaf_type: CalldataDescriptorPathLeafType = Field(
+        title="Leaf type",
+        description="Type of the leaf element",
+    )
+
+
+class CalldataDescriptorPathElementSliceV1(CalldataDescriptorPathElementBaseV1):
+    """Descriptor for the PATH_ELEMENT struct of type SLICE."""
+
+    type: Literal["SLICE"] = Field(
+        default="SLICE",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    start: int | None = Field(
+        title="Start",
+        description="Slice start index (inclusive, unset = start of data)",
+    )
+
+    end: int | None = Field(
+        title="End",
+        description="Slice end index (inclusive, unset = end of data)",
+    )
+
+
+CalldataDescriptorPathElementV1 = Annotated[
+    CalldataDescriptorPathElementTupleV1
+    | CalldataDescriptorPathElementArrayV1
+    | CalldataDescriptorPathElementRefV1
+    | CalldataDescriptorPathElementLeafV1
+    | CalldataDescriptorPathElementSliceV1,
+    Field(
+        title="Path element",
+        description="Data path element to reach the target value in the serialized transaction",
+        discriminator="type",
+    ),
+]
+
+
+class CalldataDescriptorContainerPathV1(CalldataDescriptorStructV1):
+    """Descriptor for the CONTAINER_PATH struct."""
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the CONTAINER_PATH struct",
+    )
+
+    type: Literal["CONTAINER"] = Field(
+        default="CONTAINER",
+        title="Path type",
+        description="Type of the path",
+    )
+
+    value: CalldataDescriptorContainerPathValueV1 = Field(title="Value", description="Container field")
+
+
+class CalldataDescriptorDataPathV1(CalldataDescriptorStructV1):
+    """Descriptor for the DATA_PATH struct."""
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the VALUE struct",
+    )
+
+    type: Literal["DATA"] = Field(
+        default="DATA",
+        title="Path type",
+        description="Type of the path",
+    )
+
+    elements: list[CalldataDescriptorPathElementV1] = Field(
+        title="Elements",
+        description="Path element to reach the target value",
+        min_length=1,
+        max_length=256,  # TODO to be refined
+    )
+
+
+CalldataDescriptorPathV1 = Annotated[
+    CalldataDescriptorContainerPathV1 | CalldataDescriptorDataPathV1,
+    Field(
+        title="Path",
+        description="Data or container path to reach the target value in the serialized transaction",
+        discriminator="type",
+    ),
+]
+
+
+class CalldataDescriptorValueBaseV1(CalldataDescriptorStructV1):
+    """Descriptor for the VALUE struct."""
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the VALUE struct",
+    )
+
+    type_family: CalldataDescriptorTypeFamily = Field(
+        title="Type family",
+        description="Type family of the value",
+    )
+
+    type_size: int | None = Field(
+        default=None, title="Type size", description="Size of the type (in bytes)", ge=0, le=255
+    )
+
+
+class CalldataDescriptorValuePathV1(CalldataDescriptorValueBaseV1):
+    """
+    A path to the field in the structured data. The path is a JSON path expression that can be used to extract the
+    field value from the structured data.
+    """
+
+    type: Literal["path"] = Field(
+        default="path",
+        title="Value Type",
+        description="The value type identifier (discriminator for values discriminated union).",
+    )
+
+    abi_path: ResolvedPath | None = Field(
+        default=None,
+        title="Path (source descriptor)",
+        description="Path to reach the target value in the container or serialized transaction",
+    )
+
+    binary_path: CalldataDescriptorPathV1 = Field(
+        title="Path (generic parser protocol)",
+        description="Path to reach the target value in the container or serialized transaction",
+    )
+
+
+class CalldataDescriptorValueConstantV1(CalldataDescriptorValueBaseV1):
+    """
+    A constant value.
+    """
+
+    type: Literal["constant"] = Field(
+        default="constant",
+        title="Value Type",
+        description="The value type identifier (discriminator for values discriminated union).",
+    )
+
+    value: ScalarType = Field(
+        title="Value",
+        description="The constant value.",
+    )
+
+    raw: HexStr = Field(
+        title="Raw Value",
+        description="The constant value, serialized and hex encoded.",
+    )
+
+
+CalldataDescriptorValueV1 = Annotated[
+    CalldataDescriptorValuePathV1 | CalldataDescriptorValueConstantV1,
+    Discriminator("type"),
+]

--- a/tests/convert/calldata/v1/data/paths/array_001.json
+++ b/tests/convert/calldata/v1/data/paths/array_001.json
@@ -1,0 +1,15 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1",
+  "error": "Array leaf is not supported in v1 of protocol"
+}

--- a/tests/convert/calldata/v1/data/paths/array_002.json
+++ b/tests/convert/calldata/v1/data/paths/array_002.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[0].[0].[0]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 0 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": 0, "end": 1 },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_003.json
+++ b/tests/convert/calldata/v1/data/paths/array_003.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[0].[0].[1]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 1 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": 0, "end": 1 },
+        { "type": "TUPLE", "offset": 1 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_004.json
+++ b/tests/convert/calldata/v1/data/paths/array_004.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[0].[1].[0]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 1 },
+        { "type": "array_element", "index": 0 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": 1, "end": 2 },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_005.json
+++ b/tests/convert/calldata/v1/data/paths/array_005.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[0].[1].[1]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 1 },
+        { "type": "array_element", "index": 1 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": 1, "end": 2 },
+        { "type": "TUPLE", "offset": 1 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_006.json
+++ b/tests/convert/calldata/v1/data/paths/array_006.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[0].[2].[0]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 2 },
+        { "type": "array_element", "index": 0 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": 2, "end": 3 },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_007.json
+++ b/tests/convert/calldata/v1/data/paths/array_007.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[0].[2].[1]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 2 },
+        { "type": "array_element", "index": 1 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": 2, "end": 3 },
+        { "type": "TUPLE", "offset": 1 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_008.json
+++ b/tests/convert/calldata/v1/data/paths/array_008.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[1].[0].[0]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": 1 },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 0 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 1 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": 0, "end": 1 },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_009.json
+++ b/tests/convert/calldata/v1/data/paths/array_009.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[1].[0].[1]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": 1 },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 1 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 1 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": 0, "end": 1 },
+        { "type": "TUPLE", "offset": 1 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_010.json
+++ b/tests/convert/calldata/v1/data/paths/array_010.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[0].[0].[-1]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": -1 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": 0, "end": 1 },
+        { "type": "TUPLE", "offset": 1 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_011.json
+++ b/tests/convert/calldata/v1/data/paths/array_011.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[0].[-1].[0]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": -1 },
+        { "type": "array_element", "index": 0 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": -1, "end": null },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_012.json
+++ b/tests/convert/calldata/v1/data/paths/array_012.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[0].[-2].[0]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": -2 },
+        { "type": "array_element", "index": 0 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": -2, "end": -1 },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_013.json
+++ b/tests/convert/calldata/v1/data/paths/array_013.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[-1].[0].[0]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "p1" },
+        { "type": "array_element", "index": -1 },
+        { "type": "array_element", "index": 0 },
+        { "type": "array_element", "index": 0 }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 1 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 2, "start": 0, "end": 1 },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_014.json
+++ b/tests/convert/calldata/v1/data/paths/array_014.json
@@ -1,0 +1,60 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "multiSwap",
+    "inputs": [
+      {
+        "name": "data",
+        "type": "tuple",
+        "internalType": "struct Utils.SellData",
+        "components": [
+          {
+            "name": "path",
+            "type": "tuple[]",
+            "internalType": "struct Utils.Path[]",
+            "components": [{ "name": "to", "type": "address", "internalType": "address", "components": null }]
+          }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.data.path.[-1].to",
+  "result": {
+    "version": 1,
+    "type_family": "ADDRESS",
+    "type_size": 20,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [
+        { "type": "field", "identifier": "data" },
+        { "type": "field", "identifier": "path" },
+        { "type": "array_element", "index": -1 },
+        { "type": "field", "identifier": "to" }
+      ]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 1, "start": -1, "end": null },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/array_015.json
+++ b/tests/convert/calldata/v1/data/paths/array_015.json
@@ -1,0 +1,55 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "multiSwap",
+    "inputs": [
+      {
+        "name": "data",
+        "type": "tuple",
+        "internalType": "struct Utils.SellData",
+        "components": [
+          {
+            "name": "path",
+            "type": "tuple[]",
+            "internalType": "struct Utils.Path[]",
+            "components": [{ "name": "to", "type": "address", "internalType": "address", "components": null }]
+          }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.data.path.[].to",
+  "result": {
+    "version": 1,
+    "type_family": "ADDRESS",
+    "type_size": 20,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [{ "type": "field", "identifier": "data" }, { "type": "field", "identifier": "path" }, { "type": "array" }, { "type": "field", "identifier": "to" }]
+    },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 1, "start": null, "end": null },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/dynamic_001.json
+++ b/tests/convert/calldata/v1/data/paths/dynamic_001.json
@@ -1,0 +1,34 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "bytes", "internalType": "bytes", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1",
+  "result": {
+    "version": 1,
+    "type_family": "STRING",
+    "type_size": null,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p1" }] },
+    "binary_path": { "version": 1, "type": "DATA", "elements": [{ "type": "TUPLE", "offset": 0 }, { "type": "REF" }, { "type": "LEAF", "leaf_type": "DYNAMIC_LEAF" }] }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/dynamic_002.json
+++ b/tests/convert/calldata/v1/data/paths/dynamic_002.json
@@ -1,0 +1,38 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "bytes", "internalType": "bytes", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1.[0:5]",
+  "result": {
+    "version": 1,
+    "type_family": "STRING",
+    "type_size": null,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p1" }, { "type": "array_slice", "start": 0, "end": 5 }] },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [{ "type": "TUPLE", "offset": 0 }, { "type": "REF" }, { "type": "LEAF", "leaf_type": "DYNAMIC_LEAF" }, { "type": "SLICE", "start": 0, "end": 5 }]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/dynamic_003.json
+++ b/tests/convert/calldata/v1/data/paths/dynamic_003.json
@@ -1,0 +1,26 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "bytes", "internalType": "bytes", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p2",
+  "error": "Array leaf is not supported in v1 of protocol"
+}

--- a/tests/convert/calldata/v1/data/paths/dynamic_004.json
+++ b/tests/convert/calldata/v1/data/paths/dynamic_004.json
@@ -1,0 +1,43 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "bytes", "internalType": "bytes", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p2.[0]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p2" }, { "type": "array_element", "index": 0 }] },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 1 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 1, "start": 0, "end": 1 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/dynamic_005.json
+++ b/tests/convert/calldata/v1/data/paths/dynamic_005.json
@@ -1,0 +1,43 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "bytes", "internalType": "bytes", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p2.[1]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p2" }, { "type": "array_element", "index": 1 }] },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 1 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 1, "start": 1, "end": 2 },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/dynamic_006.json
+++ b/tests/convert/calldata/v1/data/paths/dynamic_006.json
@@ -1,0 +1,43 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "bytes", "internalType": "bytes", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p2.[-1]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p2" }, { "type": "array_element", "index": -1 }] },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 1 },
+        { "type": "REF" },
+        { "type": "ARRAY", "weight": 1, "start": -1, "end": null },
+        { "type": "LEAF", "leaf_type": "STATIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/dynamic_007.json
+++ b/tests/convert/calldata/v1/data/paths/dynamic_007.json
@@ -1,0 +1,26 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "bytes", "internalType": "bytes", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p3",
+  "error": "Tuple leaf is not supported in v1 of protocol"
+}

--- a/tests/convert/calldata/v1/data/paths/dynamic_008.json
+++ b/tests/convert/calldata/v1/data/paths/dynamic_008.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "bytes", "internalType": "bytes", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p3.c",
+  "result": {
+    "version": 1,
+    "type_family": "BYTES",
+    "type_size": null,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p3" }, { "type": "field", "identifier": "c" }] },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 2 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "LEAF", "leaf_type": "DYNAMIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/dynamic_009.json
+++ b/tests/convert/calldata/v1/data/paths/dynamic_009.json
@@ -1,0 +1,44 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "bytes", "internalType": "bytes", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p3.c",
+  "result": {
+    "version": 1,
+    "type_family": "BYTES",
+    "type_size": null,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p3" }, { "type": "field", "identifier": "c" }] },
+    "binary_path": {
+      "version": 1,
+      "type": "DATA",
+      "elements": [
+        { "type": "TUPLE", "offset": 2 },
+        { "type": "REF" },
+        { "type": "TUPLE", "offset": 0 },
+        { "type": "REF" },
+        { "type": "LEAF", "leaf_type": "DYNAMIC_LEAF" }
+      ]
+    }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/static_001.json
+++ b/tests/convert/calldata/v1/data/paths/static_001.json
@@ -1,0 +1,38 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p1",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p1" }] },
+    "binary_path": { "version": 1, "type": "DATA", "elements": [{ "type": "TUPLE", "offset": 0 }, { "type": "LEAF", "leaf_type": "STATIC_LEAF" }] }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/static_002.json
+++ b/tests/convert/calldata/v1/data/paths/static_002.json
@@ -1,0 +1,38 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p2",
+  "result": {
+    "version": 1,
+    "type_family": "BOOL",
+    "type_size": 1,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p2" }] },
+    "binary_path": { "version": 1, "type": "DATA", "elements": [{ "type": "TUPLE", "offset": 1 }, { "type": "LEAF", "leaf_type": "STATIC_LEAF" }] }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/static_003.json
+++ b/tests/convert/calldata/v1/data/paths/static_003.json
@@ -1,0 +1,38 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p3.[0]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p3" }, { "type": "array_element", "index": 0 }] },
+    "binary_path": { "version": 1, "type": "DATA", "elements": [{ "type": "TUPLE", "offset": 2 }, { "type": "LEAF", "leaf_type": "STATIC_LEAF" }] }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/static_004.json
+++ b/tests/convert/calldata/v1/data/paths/static_004.json
@@ -1,0 +1,38 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p3.[-1]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p3" }, { "type": "array_element", "index": -1 }] },
+    "binary_path": { "version": 1, "type": "DATA", "elements": [{ "type": "TUPLE", "offset": 3 }, { "type": "LEAF", "leaf_type": "STATIC_LEAF" }] }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/static_005.json
+++ b/tests/convert/calldata/v1/data/paths/static_005.json
@@ -1,0 +1,38 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p4.a",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": { "type": "data", "absolute": true, "elements": [{ "type": "field", "identifier": "p4" }, { "type": "field", "identifier": "a" }] },
+    "binary_path": { "version": 1, "type": "DATA", "elements": [{ "type": "TUPLE", "offset": 4 }, { "type": "LEAF", "leaf_type": "STATIC_LEAF" }] }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/static_006.json
+++ b/tests/convert/calldata/v1/data/paths/static_006.json
@@ -1,0 +1,42 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p4.b.[0]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [{ "type": "field", "identifier": "p4" }, { "type": "field", "identifier": "b" }, { "type": "array_element", "index": 0 }]
+    },
+    "binary_path": { "version": 1, "type": "DATA", "elements": [{ "type": "TUPLE", "offset": 5 }, { "type": "LEAF", "leaf_type": "STATIC_LEAF" }] }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/static_007.json
+++ b/tests/convert/calldata/v1/data/paths/static_007.json
@@ -1,0 +1,42 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p4.b.[1]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [{ "type": "field", "identifier": "p4" }, { "type": "field", "identifier": "b" }, { "type": "array_element", "index": 1 }]
+    },
+    "binary_path": { "version": 1, "type": "DATA", "elements": [{ "type": "TUPLE", "offset": 6 }, { "type": "LEAF", "leaf_type": "STATIC_LEAF" }] }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/static_008.json
+++ b/tests/convert/calldata/v1/data/paths/static_008.json
@@ -1,0 +1,42 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p4.b.[-1]",
+  "result": {
+    "version": 1,
+    "type_family": "UINT",
+    "type_size": 32,
+    "type": "path",
+    "abi_path": {
+      "type": "data",
+      "absolute": true,
+      "elements": [{ "type": "field", "identifier": "p4" }, { "type": "field", "identifier": "b" }, { "type": "array_element", "index": -1 }]
+    },
+    "binary_path": { "version": 1, "type": "DATA", "elements": [{ "type": "TUPLE", "offset": 7 }, { "type": "LEAF", "leaf_type": "STATIC_LEAF" }] }
+  },
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/paths/static_009.json
+++ b/tests/convert/calldata/v1/data/paths/static_009.json
@@ -1,0 +1,30 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "path": "#.p4.b",
+  "error": "Array leaf is not supported in v1 of protocol"
+}

--- a/tests/convert/calldata/v1/data/values/array_001.json
+++ b/tests/convert/calldata/v1/data/values/array_001.json
@@ -1,0 +1,16 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": [[[[1,2],[3,4],[5,6]],[[7,8],[9,10]]]],
+  "path": "#.p1",
+  "error": "Array leaf is not supported in v1 of protocol"
+}

--- a/tests/convert/calldata/v1/data/values/array_002.json
+++ b/tests/convert/calldata/v1/data/values/array_002.json
@@ -1,0 +1,17 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": [[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10]]]],
+  "path": "#.p1.[0].[0].[0]",
+  "result": 1,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/array_003.json
+++ b/tests/convert/calldata/v1/data/values/array_003.json
@@ -1,0 +1,17 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": [[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10]]]],
+  "path": "#.p1.[0].[2].[0]",
+  "result": 5,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/array_004.json
+++ b/tests/convert/calldata/v1/data/values/array_004.json
@@ -1,0 +1,17 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": [[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10]]]],
+  "path": "#.p1.[0].[2].[0]",
+  "result": 5,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/array_005.json
+++ b/tests/convert/calldata/v1/data/values/array_005.json
@@ -1,0 +1,17 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_array",
+    "inputs": [{ "name": "p1", "type": "uint256[2][][2]", "internalType": "uint256[2][][2]", "components": null, "indexed": null, "unit": null }],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": [[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10]]]],
+  "path": "#.p1.[-1].[-1].[-1]",
+  "result": 10,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/dynamic_001.json
+++ b/tests/convert/calldata/v1/data/values/dynamic_001.json
@@ -1,0 +1,28 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "uint256", "internalType": "uint256", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": ["hello world", [4369, 8738], [42]],
+  "path": "#.p1",
+  "result": "hello world",
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/dynamic_002.json
+++ b/tests/convert/calldata/v1/data/values/dynamic_002.json
@@ -1,0 +1,28 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "uint256", "internalType": "uint256", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": ["hello world", [4369, 8738], [42]],
+  "path": "#.p2.[0]",
+  "result": 4369,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/dynamic_003.json
+++ b/tests/convert/calldata/v1/data/values/dynamic_003.json
@@ -1,0 +1,28 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "uint256", "internalType": "uint256", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": ["hello world", [4369, 8738], [42]],
+  "path": "#.p2.[-1]",
+  "result": 8738,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/dynamic_004.json
+++ b/tests/convert/calldata/v1/data/values/dynamic_004.json
@@ -1,0 +1,28 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_dynamic",
+    "inputs": [
+      { "name": "p1", "type": "string", "internalType": "string", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "uint256[]", "internalType": "uint256[]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p3",
+        "type": "tuple",
+        "internalType": "struct Test.T",
+        "components": [{ "name": "c", "type": "uint256", "internalType": "uint256", "components": null }],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": ["hello world", [4369, 8738], [42]],
+  "path": "#.p3.c",
+  "result": 42,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/static_001.json
+++ b/tests/convert/calldata/v1/data/values/static_001.json
@@ -1,0 +1,32 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": [42, false, [1, 2], [3, [4, 5, 6]]],
+  "path": "#.p1",
+  "result": 42,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/static_002.json
+++ b/tests/convert/calldata/v1/data/values/static_002.json
@@ -1,0 +1,32 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": [42, true, [1, 2], [3, [4, 5, 6]]],
+  "path": "#.p2",
+  "result": true,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/static_003.json
+++ b/tests/convert/calldata/v1/data/values/static_003.json
@@ -1,0 +1,32 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": [42, false, [1, 2], [3, [4, 5, 6]]],
+  "path": "#.p3.[1]",
+  "result": 2,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/static_004.json
+++ b/tests/convert/calldata/v1/data/values/static_004.json
@@ -1,0 +1,32 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": [42, false, [1, 2], [3, [4, 5, 6]]],
+  "path": "#.p4.a",
+  "result": 3,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/static_005.json
+++ b/tests/convert/calldata/v1/data/values/static_005.json
@@ -1,0 +1,32 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": [42, false, [1, 2], [3, [4, 5, 6]]],
+  "path": "#.p4.b.[0]",
+  "result": 4,
+  "error": null
+}

--- a/tests/convert/calldata/v1/data/values/static_006.json
+++ b/tests/convert/calldata/v1/data/values/static_006.json
@@ -1,0 +1,32 @@
+{
+  "abi": {
+    "type": "function",
+    "name": "test_static",
+    "inputs": [
+      { "name": "p1", "type": "uint256", "internalType": "uint256", "components": null, "indexed": null, "unit": null },
+      { "name": "p2", "type": "bool", "internalType": "bool", "components": null, "indexed": null, "unit": null },
+      { "name": "p3", "type": "uint256[2]", "internalType": "uint256[2]", "components": null, "indexed": null, "unit": null },
+      {
+        "name": "p4",
+        "type": "tuple",
+        "internalType": "struct Test.S",
+        "components": [
+          { "name": "a", "type": "uint256", "internalType": "uint256", "components": null },
+          { "name": "b", "type": "uint256[3]", "internalType": "uint256[3]", "components": null }
+        ],
+        "indexed": null,
+        "unit": null
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "pure",
+    "constant": null,
+    "payable": null,
+    "gas": null,
+    "signature": null
+  },
+  "args": [42, false, [1, 2], [3, [4, 5, 6]]],
+  "path": "#.p4.b.[-1]",
+  "result": 6,
+  "error": null
+}

--- a/tests/convert/calldata/v1/test_convert_path_data.py
+++ b/tests/convert/calldata/v1/test_convert_path_data.py
@@ -1,0 +1,108 @@
+from glob import glob
+from pathlib import Path
+from typing import Any
+
+import eth_abi
+import pytest
+from eth_utils import function_abi_to_4byte_selector, get_abi_input_types
+from pydantic import BaseModel
+
+from erc7730.common.output import RaisingOutputAdder
+from erc7730.common.pydantic import (
+    model_from_json_file_with_includes,
+    model_to_json_file,
+)
+from erc7730.convert.calldata.v1.abi import function_to_abi_tree
+from erc7730.convert.calldata.v1.path import (
+    apply_path,
+    convert_data_path,
+)
+from erc7730.model.abi import Function
+from erc7730.model.calldata.v1.value import (
+    CalldataDescriptorValueV1,
+)
+from erc7730.model.input.path import DataPathStr
+
+DATA = Path(__file__).resolve().parent / "data"
+UPDATE_REFERENCES = False
+
+
+class PathEncodingTestCase(BaseModel):
+    abi: Function
+    path: DataPathStr
+    result: CalldataDescriptorValueV1 | None = None
+    error: str | None = None
+
+
+class ValueDecodingTestCase(BaseModel):
+    abi: Function
+    args: Any
+    path: DataPathStr
+    result: Any | None = None
+    error: str | None = None
+
+
+@pytest.mark.parametrize("test_file", sorted(glob(str(DATA / "paths" / "*.json"))), ids=lambda f: Path(f).stem)
+def test_convert_paths_by_reference(test_file: str) -> None:
+    """
+    Given an ABI + an ABI path, build calldata path and check obtained result by reference.
+    """
+    test_path = Path(test_file)
+    test_case = model_from_json_file_with_includes(test_path, PathEncodingTestCase)
+
+    abi_tree = function_to_abi_tree(test_case.abi)
+
+    out = RaisingOutputAdder()
+
+    if (expected_error := test_case.error) is not None:
+        with pytest.raises(Exception) as exc_info:
+            convert_data_path(test_case.path, abi_tree, out)
+        assert expected_error in str(exc_info.value)
+    else:
+        result = convert_data_path(test_case.path, abi_tree, out)
+        if UPDATE_REFERENCES:
+            model_to_json_file(test_path, test_case.model_copy(update={"result": result}))
+            pytest.fail(f"Reference {test_file} updated, please set UPDATE_REFERENCES back to False")
+        elif (expected_result := test_case.result) is not None:
+            assert result == expected_result
+        else:
+            raise Exception("Test case is missing either 'result' or 'error' field")
+
+
+@pytest.mark.parametrize("test_file", sorted(glob(str(DATA / "values" / "*.json"))), ids=lambda f: Path(f).stem)
+def test_decode_values_by_reference(test_file: str) -> None:
+    """
+    Given an ABI + argument values + an ABI path:
+        - encode calldata arguments
+        - build calldata path
+        - apply calldata path to encoded
+        - check decoded value by reference
+    """
+    test_path = Path(test_file)
+    test_case = model_from_json_file_with_includes(test_path, ValueDecodingTestCase)
+
+    abi_dict = test_case.abi.model_dump(mode="json")
+    signature = get_abi_input_types(abi_dict)
+    selector = function_abi_to_4byte_selector(abi_dict)
+    args = eth_abi.encode(signature, test_case.args)
+    calldata = (selector + args).hex()
+
+    abi_tree = function_to_abi_tree(test_case.abi)
+
+    if (expected_error := test_case.error) is not None:
+        with pytest.raises(Exception) as exc_info:
+            path = convert_data_path(test_case.path, abi_tree, RaisingOutputAdder())
+            assert path is not None
+            apply_path(calldata, path)
+        assert expected_error in str(exc_info.value)
+    else:
+        path = convert_data_path(test_case.path, abi_tree, RaisingOutputAdder())
+        assert path is not None
+        result = apply_path(calldata, path)
+        if UPDATE_REFERENCES:
+            model_to_json_file(test_path, test_case.model_copy(update={"result": result}))
+            pytest.fail(f"Reference {test_file} updated, please set UPDATE_REFERENCES back to False")
+        elif (expected_result := test_case.result) is not None:
+            assert result == expected_result
+        else:
+            raise Exception("Test case is missing either 'result' or 'error' field")


### PR DESCRIPTION
Conversion to Ledger specific calldata descriptor (also referred to as "generic parser" descriptor).

See documentation in https://github.com/LedgerHQ/app-ethereum for specifications of this protocol.

Moved in this repository for open-sourcing, original code by @jnicoulaud-ledger 