### PR TITLE
fix: allow colon in EIP-712 type names in encodeType parser

### DIFF
--- a/src/erc7730/common/abi.py
+++ b/src/erc7730/common/abi.py
@@ -152,7 +152,7 @@ def get_functions(abis: list[ABI], *, include_read_only: bool = False) -> Functi
     return functions
 
 
-_ENCODE_TYPE_RE = re.compile(r"(\w+)\(([^)]*)\)")
+_ENCODE_TYPE_RE = re.compile(r"([\w:]+)\(([^)]*)\)")
 
 
 def parse_encode_type(encode_type: str) -> tuple[str, dict[str, list[tuple[str, str]]]]:


### PR DESCRIPTION
## Summary

- Widen `_ENCODE_TYPE_RE` regex in `common/abi.py` from `(\w+)` to `([\w:]+)` so that EIP-712 type names containing colons (e.g. `HyperliquidTransaction:Withdraw`) are correctly parsed instead of being truncated at the colon.

## Context

Hyperliquid uses colon-separated primaryType names like `HyperliquidTransaction:Withdraw` in their EIP-712 signing scheme. While `:` is technically not part of the EIP-712 spec's "valid identifier" definition, it is used in production by Hyperliquid and accepted by all major wallet implementations (MetaMask, eth_account, etc).

The `parse_encode_type` function is used by the v2-to-legacy-EIP-712 converter. Without this fix, converting a v2 descriptor with `HyperliquidTransaction:Withdraw(string hyperliquidChain,...)` as format key produces a schema with `Withdraw` instead of `HyperliquidTransaction:Withdraw`.

## Test plan

- [x] Verified `erc7730 convert erc7730-to-eip712` on a Hyperliquid withdraw v2 descriptor now produces the correct `HyperliquidTransaction:Withdraw` key in the output schema


Made with [Cursor](https://cursor.com)