### PR TITLE
fix: accept scalar values in v2 visibility rules

### DIFF
--- a/src/erc7730/common/abi.py
+++ b/src/erc7730/common/abi.py
@@ -22,7 +22,7 @@ _SIGNATURE_PARSER = parser = Lark(
             named_param: type identifier?
             named_tuple:  tuple array* identifier?
 
-            array: "[]"
+            array: "[]" | "[" /[0-9]+/ "]"
             identifier: /[a-zA-Z$_][a-zA-Z0-9$_]*/
             type: identifier array*
 
@@ -61,8 +61,8 @@ class FunctionTransformer(Transformer_InPlaceRecursive):
 
         # Separate arrays from name
         # Arrays are "[]", name is anything else
-        arrays = [elem for elem in ast[1:] if elem == "[]"]
-        names = [elem for elem in ast[1:] if elem != "[]"]
+        arrays = [elem for elem in ast[1:] if isinstance(elem, str) and elem.startswith("[")]
+        names = [elem for elem in ast[1:] if not (isinstance(elem, str) and elem.startswith("["))]
 
         # Build type with array suffixes
         type_str = "tuple" + "".join(arrays)
@@ -73,6 +73,8 @@ class FunctionTransformer(Transformer_InPlaceRecursive):
         return Component(name=name, type=type_str, components=components)
 
     def array(self, ast: Any) -> str:
+        if ast:
+            return f"[{ast[0]}]"
         return "[]"
 
     def identifier(self, ast: Any) -> str:

--- a/src/erc7730/model/input/v2/display.py
+++ b/src/erc7730/model/input/v2/display.py
@@ -31,13 +31,13 @@ class InputVisibilityConditions(Model):
     Complex visibility conditions for field display rules.
     """
 
-    ifNotIn: list[str] | None = Field(
+    ifNotIn: list[ScalarType | None] | None = Field(
         None,
         title="If Not In",
         description="Display this field only if its value is NOT in this list.",
     )
 
-    mustBe: list[str] | None = Field(
+    mustBe: list[ScalarType | None] | None = Field(
         None,
         title="Must Be",
         description="Skip displaying this field but its value MUST match one of these values.",

--- a/src/erc7730/model/resolved/v2/display.py
+++ b/src/erc7730/model/resolved/v2/display.py
@@ -32,13 +32,13 @@ class ResolvedVisibilityConditions(Model):
     Complex visibility conditions for field display rules (resolved).
     """
 
-    ifNotIn: list[str] | None = Field(
+    ifNotIn: list[ScalarType | None] | None = Field(
         None,
         title="If Not In",
         description="Display this field only if its value is NOT in this list.",
     )
 
-    mustBe: list[str] | None = Field(
+    mustBe: list[ScalarType | None] | None = Field(
         None,
         title="Must Be",
         description="Skip displaying this field but its value MUST match one of these values.",

--- a/tests/common/test_abi.py
+++ b/tests/common/test_abi.py
@@ -67,6 +67,31 @@ from erc7730.model.abi import Component, Function, InputOutput
             "mixed(bytes32[][] data, (address a,uint256 b)[][] _tuples, string name)",
             "mixed(bytes32[][],(address,uint256)[][],string)",
         ),
+        # fixed-size arrays
+        (
+            "exchange(address[11] _route, uint256[5][5] _swap_params, uint256 _amount, uint256 _min_dy)",
+            "exchange(address[11],uint256[5][5],uint256,uint256)",
+        ),
+        # fixed-size array single dimension
+        (
+            "foo(uint256[3] values)",
+            "foo(uint256[3])",
+        ),
+        # mixed fixed and dynamic arrays
+        (
+            "bar(address[5] addrs, uint256[] amounts, bytes32[2][] pairs)",
+            "bar(address[5],uint256[],bytes32[2][])",
+        ),
+        # fixed-size array of tuples
+        (
+            "baz((uint256,address)[3] items)",
+            "baz((uint256,address)[3])",
+        ),
+        # higher-dimensional fixed-size arrays
+        (
+            "multi(uint256[2][3][4] cube)",
+            "multi(uint256[2][3][4])",
+        ),
     ],
 )
 def test_reduce_signature(signature: str, expected: str) -> None:

--- a/tests/v2/convert/resolved/data/field_with_visibility_conditions_input.json
+++ b/tests/v2/convert/resolved/data/field_with_visibility_conditions_input.json
@@ -27,6 +27,24 @@
                 "0x0000000000000000000000000000000000000000"
               ]
             }
+          },
+          {
+            "path": "destinationChainId",
+            "label": "Destination Chain",
+            "visible": {
+              "mustBe": [
+                100
+              ]
+            }
+          },
+          {
+            "path": "hasSourceSwaps",
+            "label": "Has Source Swaps",
+            "visible": {
+              "mustBe": [
+                true
+              ]
+            }
           }
         ]
       }

--- a/tests/v2/convert/resolved/data/field_with_visibility_conditions_resolved.json
+++ b/tests/v2/convert/resolved/data/field_with_visibility_conditions_resolved.json
@@ -27,6 +27,24 @@
                 "0x0000000000000000000000000000000000000000"
               ]
             }
+          },
+          {
+            "label": "Destination Chain",
+            "path": "#.destinationChainId",
+            "visible": {
+              "mustBe": [
+                100
+              ]
+            }
+          },
+          {
+            "label": "Has Source Swaps",
+            "path": "#.hasSourceSwaps",
+            "visible": {
+              "mustBe": [
+                true
+              ]
+            }
           }
         ]
       }


### PR DESCRIPTION
## Summary
- align the v2 visibility condition models with the published schema so `mustBe` and `ifNotIn` accept scalar values, not just strings
- add regression coverage for numeric and boolean `mustBe` rules in the existing v2 resolved-conversion fixture
- unblock valid v2 descriptors that currently fail lint resolution when they use values like `100`, `true`, or `false`

## Test plan
- [x] `uv run --with prettydiff pytest -o addopts='' tests/v2/convert/resolved/test_convert_input_to_resolved.py -k visibility_conditions -q`
- [x] `uv run --with prettydiff pytest -o addopts='' tests/model/paths/test_path_schemas.py -q`
- [x] `uv run erc7730 lint /tmp/calldata-visibility-scalar.json` on a temp v2 descriptor using `mustBe: [100]` and `mustBe: [true]` (only ABI-key warning remained)


Made with [Cursor](https://cursor.com)