### PR TITLE
ci(release): publish to public PyPI through JFrog OIDC only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,18 +41,12 @@ jobs:
         timeout-minutes: 10
         run: pdm build
 
-      - name: Upload library artifacts to Ledger Artifactory repository
+      - name: Publish library artifacts to public PyPI via Ledger Artifactory
         timeout-minutes: 10
         env:
-          PDM_PUBLISH_REPO: https://jfrog.ledgerlabs.net/artifactory/api/pypi/vault-pypi-prod-green
+          PDM_PUBLISH_REPO: https://jfrog.ledgerlabs.net/artifactory/api/pypi/vault-pypi-prod-public
           PDM_PUBLISH_USERNAME: ${{ steps.jfrog-login.outputs.oidc-user }}
           PDM_PUBLISH_PASSWORD: ${{ steps.jfrog-login.outputs.oidc-token }}
-        run: pdm publish --no-build
-
-      - name: Upload library artifacts to PyPI
-        timeout-minutes: 10
-        env:
-          PDM_PUBLISH_PASSWORD: ${{ secrets.PYPI_PUBLIC_API_TOKEN }}
         run: pdm publish --no-build
 
       - name: Generate library build attestations


### PR DESCRIPTION
## Summary

- Stop using the long-lived `PYPI_PUBLIC_API_TOKEN` secret.
- Publish releases through JFrog OIDC to a single destination: `vault-pypi-prod-public`. JFrog forwards uploads to public PyPI via the cybersec `pypi-prd` webhook (`pypi-ledgerhq` integration).
- Drop the parallel push to `vault-pypi-prod-green`.

## Why single-push (and not dual push to `prod-green` + `prod-public`)

All local repos have `priority_resolution = true` and JFrog resolves repos inside `virtual-pypi-prod-green` in alphabetical order — `vault-pypi-prod-green` sits before `vault-pypi-prod-public`. As soon as a package name exists in `prod-green`, JFrog stops there and never inspects `prod-public`, regardless of newer versions present. Dual-push turns any partial failure into a silent split-brain (PyPI public serves the new version, internal consumers via the virtual still see the old one).

The vault project's `virtual-pypi-prod-green` already aggregates `vault-pypi-prod-public`, so internal consumers keep installing through the same virtual without change.

## Why removing the PyPI secret

- Removes a high-value, long-lived secret from this repository.
- Centralizes publishing on JFrog OIDC, consistent with other Ledger libraries publishing under the cybersec PyPI webhook.

## Dependencies / coordination

This PR depends on https://github.com/LedgerHQ/tf-jfrog/pull/new/feat/vault-pypi-prod-public-python-eip712-erc7730 which adds the `vault-pypi-prod-public` repo on the JFrog side. **Do not merge before that PR is applied by Atlantis.**

## Migration note (one-time, before first release on the new workflow)

Past releases pushed `python-erc7730` artifacts into `vault-pypi-prod-green`. Those legacy versions will shadow any new release in `vault-pypi-prod-public` for internal consumers, due to Priority Resolution + alphabetical order in `virtual-pypi-prod-green`. The legacy versions in `vault-pypi-prod-green` must be moved to (or re-published into) `vault-pypi-prod-public`, or removed, **before the first release on the new workflow**. One-time JFrog admin op, not done by CI.

## Test plan

- [ ] tf-jfrog PR merged and applied by Atlantis.
- [ ] Legacy `python-erc7730` versions migrated from `vault-pypi-prod-green` to `vault-pypi-prod-public` (admin op).
- [ ] Cut a test release (RC tag) and verify the release workflow succeeds end-to-end.
- [ ] Verify the new version is available on https://pypi.org/project/erc7730/ (via the cybersec webhook).
- [ ] Verify `pip install python-erc7730==<new-version>` works through the internal virtual.
- [ ] Remove the `PYPI_PUBLIC_API_TOKEN` secret from the repo settings once a release has succeeded.

Made with [Cursor](https://cursor.com)