### PR TITLE
feat: add tokenTicker and chainId calldata formatters

### DIFF
--- a/src/erc7730/convert/calldata/convert_erc7730_v2_input_to_calldata.py
+++ b/src/erc7730/convert/calldata/convert_erc7730_v2_input_to_calldata.py
@@ -49,6 +49,7 @@ from erc7730.model.calldata.v1.param import (
     CalldataDescriptorParamDatetimeV1,
     CalldataDescriptorParamDurationV1,
     CalldataDescriptorParamEnumV1,
+    CalldataDescriptorParamNetworkV1,
     CalldataDescriptorParamNFTV1,
     CalldataDescriptorParamRawV1,
     CalldataDescriptorParamTokenAmountV1,
@@ -598,6 +599,10 @@ def _convert_v2_param(
                 )
             # native_currencies is left unset: PARAM_TOKEN supports NATIVE_CURRENCY, but tokenTicker has no such param.
             return CalldataDescriptorParamTokenV1(value=value)
+
+        case FieldFormat.CHAIN_ID:
+            # chainId maps to PARAM_NETWORK: the field value is the chain ID, network name is resolved by the device.
+            return CalldataDescriptorParamNetworkV1(value=value)
 
         case FieldFormat.TOKEN_AMOUNT:
             token_path: CalldataDescriptorValueV1 | None = None

--- a/src/erc7730/convert/calldata/convert_erc7730_v2_input_to_calldata.py
+++ b/src/erc7730/convert/calldata/convert_erc7730_v2_input_to_calldata.py
@@ -52,6 +52,7 @@ from erc7730.model.calldata.v1.param import (
     CalldataDescriptorParamNFTV1,
     CalldataDescriptorParamRawV1,
     CalldataDescriptorParamTokenAmountV1,
+    CalldataDescriptorParamTokenV1,
     CalldataDescriptorParamTrustedNameV1,
     CalldataDescriptorParamUnitV1,
     CalldataDescriptorParamV1,
@@ -584,6 +585,19 @@ def _convert_v2_param(
 
         case FieldFormat.AMOUNT:
             return CalldataDescriptorParamAmountV1(value=value)
+
+        case FieldFormat.TOKEN_TICKER:
+            # tokenTicker maps to PARAM_TOKEN: the field value is the token address, ticker is resolved by the device.
+            # chainId/chainIdPath have no equivalent tag in PARAM_TOKEN, so they cannot be encoded and are ignored.
+            if field.params is not None and (
+                getattr(field.params, "chainId", None) is not None
+                or getattr(field.params, "chainIdPath", None) is not None
+            ):
+                out.warning(
+                    "tokenTicker chainId/chainIdPath cannot be encoded in the PARAM_TOKEN struct and will be ignored."
+                )
+            # native_currencies is left unset: PARAM_TOKEN supports NATIVE_CURRENCY, but tokenTicker has no such param.
+            return CalldataDescriptorParamTokenV1(value=value)
 
         case FieldFormat.TOKEN_AMOUNT:
             token_path: CalldataDescriptorValueV1 | None = None

--- a/src/erc7730/convert/calldata/v1/tlv.py
+++ b/src/erc7730/convert/calldata/v1/tlv.py
@@ -22,6 +22,7 @@ from erc7730.model.calldata.v1.param import (
     CalldataDescriptorParamDatetimeV1,
     CalldataDescriptorParamDurationV1,
     CalldataDescriptorParamEnumV1,
+    CalldataDescriptorParamNetworkV1,
     CalldataDescriptorParamNFTV1,
     CalldataDescriptorParamRawV1,
     CalldataDescriptorParamTokenAmountV1,
@@ -166,6 +167,12 @@ class CalldataDescriptorParamTokenTag(IntEnum):
 
 
 @pydantic_enum_by_name
+class CalldataDescriptorParamNetworkTag(IntEnum):
+    VERSION = 0x00
+    VALUE = 0x01
+
+
+@pydantic_enum_by_name
 class CalldataDescriptorValueTag(IntEnum):
     VERSION = 0x00
     TYPE_FAMILY = 0x01
@@ -297,6 +304,9 @@ def tlv_field(obj: CalldataDescriptorInstructionFieldV1) -> bytes:
         case CalldataDescriptorParamTokenV1():
             param_type = CalldataDescriptorParamType.TOKEN
             param_value = tlv_param_token(obj.param)
+        case CalldataDescriptorParamNetworkV1():
+            param_type = CalldataDescriptorParamType.NETWORK
+            param_value = tlv_param_network(obj.param)
         case _:
             assert_never(obj.param)
 
@@ -503,6 +513,20 @@ def tlv_param_token(obj: CalldataDescriptorParamTokenV1) -> bytes:
     if (native_currencies := obj.native_currencies) is not None:
         for currency in native_currencies:
             out += tlv(CalldataDescriptorParamTokenTag.NATIVE_CURRENCY, from_hex(currency))
+
+    return out
+
+
+def tlv_param_network(obj: CalldataDescriptorParamNetworkV1) -> bytes:
+    """
+    Encode a struct of type PARAM_NETWORK.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorParamNetworkTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorParamNetworkTag.VALUE, tlv_value(obj.value))
 
     return out
 

--- a/src/erc7730/convert/calldata/v1/tlv.py
+++ b/src/erc7730/convert/calldata/v1/tlv.py
@@ -25,6 +25,7 @@ from erc7730.model.calldata.v1.param import (
     CalldataDescriptorParamNFTV1,
     CalldataDescriptorParamRawV1,
     CalldataDescriptorParamTokenAmountV1,
+    CalldataDescriptorParamTokenV1,
     CalldataDescriptorParamTrustedNameV1,
     CalldataDescriptorParamType,
     CalldataDescriptorParamUnitV1,
@@ -158,6 +159,13 @@ class CalldataDescriptorParamCalldataTag(IntEnum):
 
 
 @pydantic_enum_by_name
+class CalldataDescriptorParamTokenTag(IntEnum):
+    VERSION = 0x00
+    ADDRESS = 0x01
+    NATIVE_CURRENCY = 0x02
+
+
+@pydantic_enum_by_name
 class CalldataDescriptorValueTag(IntEnum):
     VERSION = 0x00
     TYPE_FAMILY = 0x01
@@ -286,6 +294,9 @@ def tlv_field(obj: CalldataDescriptorInstructionFieldV1) -> bytes:
         case CalldataDescriptorParamCalldataV1():
             param_type = CalldataDescriptorParamType.CALLDATA
             param_value = tlv_param_calldata(obj.param)
+        case CalldataDescriptorParamTokenV1():
+            param_type = CalldataDescriptorParamType.TOKEN
+            param_value = tlv_param_token(obj.param)
         case _:
             assert_never(obj.param)
 
@@ -474,6 +485,24 @@ def tlv_param_calldata(obj: CalldataDescriptorParamCalldataV1) -> bytes:
         out += tlv(CalldataDescriptorParamCalldataTag.AMOUNT, tlv_value(amount))
     if (spender := obj.spender) is not None:
         out += tlv(CalldataDescriptorParamCalldataTag.SPENDER, tlv_value(spender))
+
+    return out
+
+
+def tlv_param_token(obj: CalldataDescriptorParamTokenV1) -> bytes:
+    """
+    Encode a struct of type PARAM_TOKEN.
+
+    @param obj: object representation of struct
+    @return: encoded struct TLV
+    """
+    out = bytearray()
+    out += tlv(CalldataDescriptorParamTokenTag.VERSION, obj.version.to_bytes(1))
+    out += tlv(CalldataDescriptorParamTokenTag.ADDRESS, tlv_value(obj.value))
+
+    if (native_currencies := obj.native_currencies) is not None:
+        for currency in native_currencies:
+            out += tlv(CalldataDescriptorParamTokenTag.NATIVE_CURRENCY, from_hex(currency))
 
     return out
 

--- a/src/erc7730/convert/resolved/v2/convert_erc7730_input_to_resolved.py
+++ b/src/erc7730/convert/resolved/v2/convert_erc7730_input_to_resolved.py
@@ -283,12 +283,19 @@ class ERC7730InputToResolved(ERC7730Converter[InputERC7730Descriptor, ResolvedER
         out: OutputAdder,
     ) -> ResolvedFieldDescription | None:
         match definition.format:
-            case None | FieldFormat.RAW | FieldFormat.AMOUNT | FieldFormat.TOKEN_AMOUNT | FieldFormat.DURATION:
+            # tokenTicker parameters (chainId/chainIdPath) are all optional per schema, so a bare field is valid
+            case (
+                None
+                | FieldFormat.RAW
+                | FieldFormat.AMOUNT
+                | FieldFormat.TOKEN_AMOUNT
+                | FieldFormat.TOKEN_TICKER
+                | FieldFormat.DURATION
+            ):
                 pass
             case (
                 FieldFormat.ADDRESS_NAME
                 | FieldFormat.INTEROPERABLE_ADDRESS_NAME
-                | FieldFormat.TOKEN_TICKER
                 | FieldFormat.CALL_DATA
                 | FieldFormat.NFT_NAME
                 | FieldFormat.DATE

--- a/src/erc7730/model/calldata/v1/param.py
+++ b/src/erc7730/model/calldata/v1/param.py
@@ -34,6 +34,7 @@ class CalldataDescriptorParamType(IntEnum):
     ENUM = 0x07
     TRUSTED_NAME = 0x08
     CALLDATA = 0x09
+    TOKEN = 0x0A
 
 
 class CalldataDescriptorDateType(IntEnum):
@@ -309,6 +310,26 @@ class CalldataDescriptorParamCalldataV1(CalldataDescriptorParamBaseV1):
     )
 
 
+class CalldataDescriptorParamTokenV1(CalldataDescriptorParamBaseV1):
+    """Descriptor for the PARAM_TOKEN struct."""
+
+    type: Literal["TOKEN"] = Field(
+        default="TOKEN",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the PARAM_TOKEN struct",
+    )
+
+    native_currencies: list[Address] | None = Field(
+        default=None, title="Native currencies", description="Addresses to interpret as native currency"
+    )
+
+
 CalldataDescriptorParamV1 = Annotated[
     CalldataDescriptorParamRawV1
     | CalldataDescriptorParamAmountV1
@@ -319,7 +340,8 @@ CalldataDescriptorParamV1 = Annotated[
     | CalldataDescriptorParamUnitV1
     | CalldataDescriptorParamEnumV1
     | CalldataDescriptorParamTrustedNameV1
-    | CalldataDescriptorParamCalldataV1,
+    | CalldataDescriptorParamCalldataV1
+    | CalldataDescriptorParamTokenV1,
     Field(
         title="Field parameter",
         description="Format specific parameters for a calldata descriptor field.",

--- a/src/erc7730/model/calldata/v1/param.py
+++ b/src/erc7730/model/calldata/v1/param.py
@@ -35,6 +35,7 @@ class CalldataDescriptorParamType(IntEnum):
     TRUSTED_NAME = 0x08
     CALLDATA = 0x09
     TOKEN = 0x0A
+    NETWORK = 0x0B
 
 
 class CalldataDescriptorDateType(IntEnum):
@@ -330,6 +331,22 @@ class CalldataDescriptorParamTokenV1(CalldataDescriptorParamBaseV1):
     )
 
 
+class CalldataDescriptorParamNetworkV1(CalldataDescriptorParamBaseV1):
+    """Descriptor for the PARAM_NETWORK struct."""
+
+    type: Literal["NETWORK"] = Field(
+        default="NETWORK",
+        title="Parameter type",
+        description="Type of the parameter",
+    )
+
+    version: Literal[1] = Field(
+        default=1,
+        title="Struct version",
+        description="Version of the PARAM_NETWORK struct",
+    )
+
+
 CalldataDescriptorParamV1 = Annotated[
     CalldataDescriptorParamRawV1
     | CalldataDescriptorParamAmountV1
@@ -341,7 +358,8 @@ CalldataDescriptorParamV1 = Annotated[
     | CalldataDescriptorParamEnumV1
     | CalldataDescriptorParamTrustedNameV1
     | CalldataDescriptorParamCalldataV1
-    | CalldataDescriptorParamTokenV1,
+    | CalldataDescriptorParamTokenV1
+    | CalldataDescriptorParamNetworkV1,
     Field(
         title="Field parameter",
         description="Format specific parameters for a calldata descriptor field.",

--- a/tests/v2/convert/calldata/test_convert_chain_id.py
+++ b/tests/v2/convert/calldata/test_convert_chain_id.py
@@ -1,0 +1,52 @@
+from erc7730.convert.calldata.convert_erc7730_v2_input_to_calldata import (
+    erc7730_v2_descriptor_to_calldata_descriptors,
+)
+from erc7730.convert.calldata.v1.tlv import tlv_field
+from erc7730.model.calldata.v1.param import (
+    CalldataDescriptorParamNetworkV1,
+    CalldataDescriptorParamType,
+)
+from erc7730.model.input.v2.descriptor import InputERC7730Descriptor
+
+CHAIN_ID_DESCRIPTOR = """
+{
+  "$schema": "specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "chain-id-test",
+    "contract": {
+      "deployments": [
+        { "chainId": 1, "address": "0x0000000000000000000000000000000000000001" }
+      ]
+    }
+  },
+  "metadata": { "owner": "Test Owner" },
+  "display": {
+    "formats": {
+      "bridge(uint256 chainId)": {
+        "intent": "Bridge to network",
+        "fields": [
+          { "path": "chainId", "label": "Network", "format": "chainId" }
+        ]
+      }
+    }
+  }
+}
+"""
+
+
+def test_convert_chain_id() -> None:
+    descriptor = InputERC7730Descriptor.model_validate_json(CHAIN_ID_DESCRIPTOR)
+
+    descriptors = erc7730_v2_descriptor_to_calldata_descriptors(descriptor, chain_id=1)
+
+    assert len(descriptors) == 1
+    fields = descriptors[0].fields
+    assert len(fields) == 1
+
+    field = fields[0]
+    assert field.name == "Network"
+    assert isinstance(field.param, CalldataDescriptorParamNetworkV1)
+
+    # PARAM_TYPE tag (0x02) must serialize the NETWORK parameter type (0x0b)
+    tlv = tlv_field(field)
+    assert bytes([0x02, 0x01, CalldataDescriptorParamType.NETWORK]) in tlv

--- a/tests/v2/convert/calldata/test_convert_token_ticker.py
+++ b/tests/v2/convert/calldata/test_convert_token_ticker.py
@@ -1,0 +1,53 @@
+from erc7730.convert.calldata.convert_erc7730_v2_input_to_calldata import (
+    erc7730_v2_descriptor_to_calldata_descriptors,
+)
+from erc7730.convert.calldata.v1.tlv import tlv_field
+from erc7730.model.calldata.v1.param import (
+    CalldataDescriptorParamTokenV1,
+    CalldataDescriptorParamType,
+)
+from erc7730.model.input.v2.descriptor import InputERC7730Descriptor
+
+TOKEN_TICKER_DESCRIPTOR = """
+{
+  "$schema": "specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "token-ticker-test",
+    "contract": {
+      "deployments": [
+        { "chainId": 1, "address": "0x0000000000000000000000000000000000000001" }
+      ]
+    }
+  },
+  "metadata": { "owner": "Test Owner" },
+  "display": {
+    "formats": {
+      "getTokenTicker(address token)": {
+        "intent": "Get token ticker",
+        "fields": [
+          { "path": "token", "label": "Token", "format": "tokenTicker" }
+        ]
+      }
+    }
+  }
+}
+"""
+
+
+def test_convert_token_ticker() -> None:
+    descriptor = InputERC7730Descriptor.model_validate_json(TOKEN_TICKER_DESCRIPTOR)
+
+    descriptors = erc7730_v2_descriptor_to_calldata_descriptors(descriptor, chain_id=1)
+
+    assert len(descriptors) == 1
+    fields = descriptors[0].fields
+    assert len(fields) == 1
+
+    field = fields[0]
+    assert field.name == "Token"
+    assert isinstance(field.param, CalldataDescriptorParamTokenV1)
+    assert field.param.native_currencies is None
+
+    # PARAM_TYPE tag (0x02) must serialize the TOKEN parameter type (0x0a)
+    tlv = tlv_field(field)
+    assert bytes([0x02, 0x01, CalldataDescriptorParamType.TOKEN]) in tlv


### PR DESCRIPTION
## Summary

Implements two new ERC-7730 v2 field formatters in the calldata (TLV) conversion path, mapping them to the corresponding app-ethereum generic parser structs:

- **`tokenTicker` → `PARAM_TOKEN`** (`ParamType` `0x0a`): the field value is the token address; the device resolves the ticker.
- **`chainId` → `PARAM_NETWORK`** (`ParamType` `0x0b`): the field value references the chain ID; the device resolves the network name and falls back to the raw chain ID if unknown.

Both were previously unsupported and fell through to an "Unsupported format" error.

## Details

### `tokenTicker` / `PARAM_TOKEN`
- Added `CalldataDescriptorParamTokenV1` model (`TOKEN = 0x0A`) with `native_currencies` kept for TLV fidelity to the struct's `NATIVE_CURRENCY` tag (not populated by `tokenTicker`).
- Added the `tlv_param_token` encoder and tag enum (VERSION / ADDRESS / NATIVE_CURRENCY).
- `tokenTicker` parameters (`chainId` / `chainIdPath`) are optional per schema and have no equivalent tag in `PARAM_TOKEN`, so they are ignored with a warning.
- Fixed the resolved converter to treat `tokenTicker` params as optional (previously errored on a bare field).

### `chainId` / `PARAM_NETWORK`
- Added `CalldataDescriptorParamNetworkV1` model (`NETWORK = 0x0B`).
- Added the `tlv_param_network` encoder and tag enum (VERSION / VALUE).
- Added the `CHAIN_ID` case to the v2 → calldata converter.

## Testing
- New unit tests asserting each format serializes the correct `PARAM_TYPE` tag (`0x0a` / `0x0b`) in the TLV output.
- Full calldata + v2 suites pass (74 passed); ruff, mypy, bandit clean via pre-commit.

## Reference
Structs follow the app-ethereum TLV spec: `doc/tlv_structs.md`.