### PR TITLE
feat: align v2 with spec (`@.chainId` path and `metadata.contractName`)

### DIFF
--- a/src/erc7730/convert/calldata/convert_erc7730_v2_input_to_calldata.py
+++ b/src/erc7730/convert/calldata/convert_erc7730_v2_input_to_calldata.py
@@ -235,7 +235,7 @@ def _convert_v2_selector(
         creator_name=descriptor.metadata.owner,
         creator_legal_name=creator_legal_name,
         creator_url=creator_url,
-        contract_name=descriptor.context.id,
+        contract_name=descriptor.metadata.contractName or descriptor.context.id,
         deploy_date=deploy_date,
     )
 

--- a/src/erc7730/convert/calldata/v1/path.py
+++ b/src/erc7730/convert/calldata/v1/path.py
@@ -136,6 +136,10 @@ def convert_container_path(
             field = CalldataDescriptorContainerPathValueV1.VALUE
             type_family = CalldataDescriptorTypeFamily.UINT
             type_size = 32
+        case ContainerField.CHAIN_ID:
+            field = CalldataDescriptorContainerPathValueV1.CHAIN_ID
+            type_family = CalldataDescriptorTypeFamily.UINT
+            type_size = 32
         case _:
             assert_never(path.field)
     return CalldataDescriptorValuePathV1(

--- a/src/erc7730/convert/ledger/eip712/convert_erc7730_v2_to_eip712.py
+++ b/src/erc7730/convert/ledger/eip712/convert_erc7730_v2_to_eip712.py
@@ -483,16 +483,18 @@ class ERC7730V2toEIP712Converter:
         domain = context.eip712.domain
         has_deployments = len(context.eip712.deployments) > 0
 
-        # Get contract name from metadata
-        contract_name = descriptor.metadata.owner
-        if contract_name is None:
+        # owner is required for legacy EIP-712 conversion
+        if (owner := descriptor.metadata.owner) is None:
             return out.error(
                 title="Missing owner",
                 message="metadata.owner is required for legacy EIP-712 conversion.",
             )
 
+        # Get contract name from metadata, preferring the explicit contractName field
+        contract_name = descriptor.metadata.contractName or owner
+
         # Get dapp name: prefer domain.name, fall back to metadata.owner
-        dapp_name: str = (domain.name if domain is not None and domain.name is not None else None) or contract_name
+        dapp_name: str = (domain.name if domain is not None and domain.name is not None else None) or owner
 
         # Reconstruct EIP712Domain type
         domain_fields = _reconstruct_eip712_domain(domain, has_deployments, out)

--- a/src/erc7730/lint/v2/lint_validate_max_length.py
+++ b/src/erc7730/lint/v2/lint_validate_max_length.py
@@ -62,10 +62,11 @@ class ValidateMaxLengthLinter(ERC7730Linter):
                     f"{CREATOR_URL_MAX_LENGTH} characters and may be truncated on Ledger devices.",
                 )
 
-        if descriptor.context.id is not None and len(descriptor.context.id) > CONTRACT_NAME_MAX_LENGTH:
+        contract_name = descriptor.metadata.contractName or descriptor.context.id
+        if contract_name is not None and len(contract_name) > CONTRACT_NAME_MAX_LENGTH:
             out.warning(
-                title="Contract id too long",
-                message=f"Contract id `{descriptor.context.id}` exceeds "
+                title="Contract name too long",
+                message=f"Contract name `{contract_name}` exceeds "
                 f"{CONTRACT_NAME_MAX_LENGTH} characters and may be truncated on Ledger devices.",
             )
 

--- a/src/erc7730/model/calldata/v1/value.py
+++ b/src/erc7730/model/calldata/v1/value.py
@@ -77,6 +77,7 @@ class CalldataDescriptorContainerPathValueV1(IntEnum):
     FROM = 0x0
     TO = 0x1
     VALUE = 0x2
+    CHAIN_ID = 0x3
 
 
 class CalldataDescriptorPathElementBaseV1(Model):

--- a/src/erc7730/model/paths/__init__.py
+++ b/src/erc7730/model/paths/__init__.py
@@ -123,6 +123,9 @@ class ContainerField(StrEnum):
     TO = auto()
     """The destination address of the containing transaction, ie the target smart contract address."""
 
+    CHAIN_ID = "chainId"
+    """The chain id of the transaction / verifying contract of the message."""
+
 
 DataPathElement = Annotated[
     Field | ArrayElement | ArraySlice | Array,

--- a/src/erc7730/model/paths/path_parser.py
+++ b/src/erc7730/model/paths/path_parser.py
@@ -25,7 +25,7 @@ PATH_PARSER = Lark(
         ?descriptor_path_component: field | array_element
     
         container_path: "@." container_field
-        !container_field: "from" | "to" | "value"
+        !container_field: "from" | "to" | "value" | "chainId"
     
         ?data_path: absolute_data_path | relative_data_path
         absolute_data_path: "#." data_path_component ("." data_path_component)*

--- a/tests/model/paths/test_path_parser.py
+++ b/tests/model/paths/test_path_parser.py
@@ -40,6 +40,14 @@ def test_valid_input_container_path() -> None:
     )
 
 
+def test_valid_input_container_path_chain_id() -> None:
+    _test_valid_input_path(
+        string="@.chainId",
+        obj=ContainerPath(field=ContainerField.CHAIN_ID),
+        json="""{ "type": "container", "field": "chainId" }""",
+    )
+
+
 def test_valid_input_data_path_absolute() -> None:
     _test_valid_input_path(
         string="#.params.[].[-2].[1:5].[:5].[5:].amountIn",
@@ -132,6 +140,14 @@ def test_valid_resolved_container_path() -> None:
         string="@.to",
         obj=ContainerPath(field=ContainerField.TO),
         json="""{ "type": "container", "field": "to" }""",
+    )
+
+
+def test_valid_resolved_container_path_chain_id() -> None:
+    _test_valid_resolved_path(
+        string="@.chainId",
+        obj=ContainerPath(field=ContainerField.CHAIN_ID),
+        json="""{ "type": "container", "field": "chainId" }""",
     )
 
 


### PR DESCRIPTION
## Summary

Aligns the v2 implementation with the ERC-7730 spec on two points.

### 1. Implement `@.chainId` container path

The spec lists `@.chainId` as a canonical container field (for both EVM transaction and EIP-712 containers), notably used as a map `keyPath` (e.g. `underlyingToken` keyed by chain id). This adds full support for it:

- Added `CHAIN_ID = "chainId"` to `ContainerField`.
- Added `chainId` to the path parser grammar.
- Added `CHAIN_ID = 0x3` to the calldata binary value enum and handled it in `convert_container_path` (encoded as a 32-byte `UINT`).
- Added parsing tests for `@.chainId`.

### 2. Use `metadata.contractName` for the contract name

Prefer the explicit `metadata.contractName` field where a contract name is set, falling back to the previous value when not available:

- Calldata v2 conversion: `metadata.contractName or context.id`.
- Legacy EIP-712 v2 conversion: `InputEIP712Contract.contractName` prefers `metadata.contractName`, falling back to `metadata.owner` (dapp name keeps its owner-based fallback).
- v2 max-length lint validates the effective contract name (`metadata.contractName or context.id`).

v1 paths are left untouched since v1 metadata has no `contractName` field.

## Testing

- `pdm run pytest tests/model tests/convert tests/v2 tests/lint` — all passing.
- Pre-commit hooks (ruff, mypy, bandit, etc.) pass.
