### PR TITLE
ci: build and deploy docs only on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,21 +73,14 @@ jobs:
           path: tests/.tests.xml
           include-hidden-files: true
 
+      # Build docs on every PR to catch errors early (no artifact upload).
       - name: Build docs
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         run: pdm run docs
 
-      - name: Upload docs artifact
-        timeout-minutes: 10
-        if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: docs-build
-          path: "./docs/build"
-
   # ──────────────────────────────────────────────────────────────────
-  # Deploy docs — only on push to main
+  # Build & deploy docs — only on push to main
   # ──────────────────────────────────────────────────────────────────
   deploy-docs:
     name: deploy docs
@@ -95,16 +88,32 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     permissions:
+      contents: read
       pages: write
       id-token: write
     steps:
-      - name: Download docs artifact
+      - name: Checkout
         timeout-minutes: 10
-        uses: actions/download-artifact@v8
+        uses: actions/checkout@v7
         with:
-          name: docs-build
-          path: "./docs/build"
+          fetch-depth: 0
+          submodules: "recursive"
+
+      - name: Setup mise
+        timeout-minutes: 10
+        uses: jdx/mise-action@v4.2.3
+
+      - name: Install dependencies
+        timeout-minutes: 10
+        run: pdm install --dev --check --frozen-lockfile
+
+      - name: Build docs
+        timeout-minutes: 10
+        run: pdm run docs
 
       - name: Setup Github Pages
         timeout-minutes: 10
@@ -117,5 +126,6 @@ jobs:
           path: "./docs/build"
 
       - name: Deploy GitHub Pages
+        id: deployment
         timeout-minutes: 10
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Fixes the `deploy docs` job that was timing out on `main` (the Pages deployment stayed stuck in `deployment_queued` and eventually failed after 10 minutes).

## Changes

- Build docs on **every PR** (in the `ci` job) to catch build errors early, without uploading any artifact.
- Made `deploy-docs` a self-contained job that **builds and deploys** docs, gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`.
- Declared the `github-pages` environment on the deploy job, which `actions/deploy-pages` requires. Without it the deployment never resolves and times out — the root cause of the failure.

## Result

Docs are built on every PR to anticipate errors, and built + deployed to GitHub Pages only on push to `main`, where the Pages deploy step now resolves correctly instead of hanging.