### PR TITLE
ci: revert PR #322 and fix docs deploy with github-pages environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     permissions:
       pages: write
       id-token: write
@@ -117,5 +120,6 @@ jobs:
           path: "./docs/build"
 
       - name: Deploy GitHub Pages
+        id: deployment
         timeout-minutes: 10
         uses: actions/deploy-pages@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,14 +73,21 @@ jobs:
           path: tests/.tests.xml
           include-hidden-files: true
 
-      # Build docs on every PR to catch errors early (no artifact upload).
       - name: Build docs
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         run: pdm run docs
 
+      - name: Upload docs artifact
+        timeout-minutes: 10
+        if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-build
+          path: "./docs/build"
+
   # ──────────────────────────────────────────────────────────────────
-  # Build & deploy docs — only on push to main
+  # Deploy docs — only on push to main
   # ──────────────────────────────────────────────────────────────────
   deploy-docs:
     name: deploy docs
@@ -88,32 +95,16 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     permissions:
-      contents: read
       pages: write
       id-token: write
     steps:
-      - name: Checkout
+      - name: Download docs artifact
         timeout-minutes: 10
-        uses: actions/checkout@v7
+        uses: actions/download-artifact@v8
         with:
-          fetch-depth: 0
-          submodules: "recursive"
-
-      - name: Setup mise
-        timeout-minutes: 10
-        uses: jdx/mise-action@v4.2.3
-
-      - name: Install dependencies
-        timeout-minutes: 10
-        run: pdm install --dev --check --frozen-lockfile
-
-      - name: Build docs
-        timeout-minutes: 10
-        run: pdm run docs
+          name: docs-build
+          path: "./docs/build"
 
       - name: Setup Github Pages
         timeout-minutes: 10
@@ -126,6 +117,5 @@ jobs:
           path: "./docs/build"
 
       - name: Deploy GitHub Pages
-        id: deployment
         timeout-minutes: 10
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Reverts PR #322 and applies a minimal fix instead: the docs deployment was timing out on `main` because the `deploy-docs` job never declared the `github-pages` environment, so the Pages deployment stayed stuck in `deployment_queued` and failed after 10 minutes.

## Changes

- Revert PR #322 ("Build and deploy docs only on push to main"), restoring the original build-once / upload-artifact / download-and-deploy flow.
- Add the `github-pages` environment (with `url: ${{ steps.deployment.outputs.page_url }}`) to the `deploy-docs` job and an `id: deployment` on the deploy step. `actions/deploy-pages` requires the job to target this environment; without it the deployment never resolves and times out — the root cause of the failure.

## Result

Docs are built once in `ci`, the artifact is uploaded only on push to `main`, and the `deploy-docs` job now deploys to GitHub Pages successfully instead of hanging.