### PR TITLE
Increase GitHub Pages deploy timeout to absorb queue backlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: ci
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -121,5 +121,9 @@ jobs:
 
       - name: Deploy GitHub Pages
         id: deployment
-        timeout-minutes: 10
+        timeout-minutes: 30
         uses: actions/deploy-pages@v5
+        with:
+          # Pages runner backlog can spend several minutes in the queue before
+          # the build starts; give the deployment more room than the 10min default.
+          timeout: 1500000


### PR DESCRIPTION
## Summary

The `deploy docs` job keeps timing out after 10 minutes. Digging into the deploy logs of run [31106667493](https://github.com/LedgerHQ/python-erc7730/actions/runs/31106667493/job/92640358902) shows it isn't permanently stuck — it's **slow**:

- ~5.4 min in `Current status: deployment_queued` (GitHub Pages runner backlog before the build even starts)
- then `Current status: deployment_in_progress`, still building when the action's **10-minute total timeout** cancelled it → `failure`

The queue phase alone eats more than half the budget, so the actual Pages build never gets enough time to finish.

## Changes

- Raise the `actions/deploy-pages` step `timeout` input to `1500000` ms (25 min) — the action defaults to 10 min, which is too tight given the queue backlog.
- Raise the step `timeout-minutes` to 30 and the job `timeout-minutes` to 40 so the longer deploy fits within the job budget.

## Notes

The `github-pages` environment (added earlier) is correct and remains. This PR only gives the deployment enough time to get through the queue and complete.